### PR TITLE
add unsubscribe and email preferences redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -140,6 +140,14 @@ http {
             return 301 https://panoptes.zooniverse.org/api/events;
         }
 
+        location /account/newsletters {
+            return 301 /#/settings/email;
+        }
+
+        location /unsubscribe {
+            return 301 /#/unsubscribe;
+        }
+
         include /etc/nginx/proxy.conf;
     }
 


### PR DESCRIPTION
ensure the old old zoo home email links still work and point to the relevant pages.