### PR TITLE
Redirect all non-content requests to html page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN mkdir -p /nginx-cache/ /var/log/static/ /logstash/static/ && \
 
 ADD nginx.conf /etc/nginx/nginx.conf
 ADD nginx-redirects.conf /etc/nginx/redirects.conf
+ADD nginx-hashless-proxy.conf /etc/nginx/hashless-proxy.conf
 ADD nginx-proxy.conf /etc/nginx/proxy.conf
 ADD logstash-nginx.conf /logstash/static/logstash-nginx.conf
 

--- a/nginx-hashless-proxy.conf
+++ b/nginx-hashless-proxy.conf
@@ -1,0 +1,41 @@
+location ~ \.(js|css)$ {
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Credentials' 'true';
+    add_header 'Access-Control-Allow-Methods' 'GET';
+    add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+
+    resolver 8.8.8.8;
+    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$uri?$query_string;
+    proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
+    proxy_redirect         /$host/ /;
+    proxy_cache            STATIC;
+    proxy_cache_valid      200  1d;
+    proxy_cache_use_stale  error timeout invalid_header updating
+                http_500 http_502 http_503 http_504;
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    proxy_hide_header Access-Control-Allow-Methods;
+    proxy_hide_header Access-Control-Allow-Headers;
+}
+
+location / {
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Credentials' 'true';
+    add_header 'Access-Control-Allow-Methods' 'GET';
+    add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+
+    rewrite (?i)\.(jp(e)?g|gif|png|mp(3|4)|pdf|zip)$ https://static.zooniverse.org/$host$uri;
+
+    resolver 8.8.8.8;
+    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host/;
+    proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
+    proxy_redirect         /$host/ /;
+    proxy_cache            STATIC;
+    proxy_cache_valid      200  1d;
+    proxy_cache_use_stale  error timeout invalid_header updating
+                http_500 http_502 http_503 http_504;
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Access-Control-Allow-Credentials;
+    proxy_hide_header Access-Control-Allow-Methods;
+    proxy_hide_header Access-Control-Allow-Headers;
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -114,23 +114,19 @@ http {
         server_name www.zooniverse.org;
 
         location /password/reset {
-            return 301 /#/reset-password;
+            return 301 /reset-password;
         }
 
         location /projects/current {
             return 301 /;
         }
 
-        location /projects {
-            return 301 /#/projects;
-        }
-
         location /signup {
-            return 301 /#/accounts/register;
+            return 301 /accounts/register;
         }
 
         location /publications {
-            return 301 /#/about/publications;
+            return 301 /about/publications;
         }
 
         location /api/events {
@@ -138,50 +134,46 @@ http {
         }
 
         location /account/newsletters {
-            return 301 /#/settings/email;
+            return 301 /settings/email;
         }
 
         location /lab {
-            return 301 /#/lab;
+            return 301 /lab;
         }
 
         location ~* /project(_|-)?builder$ {
-            return 301 /#/lab;
+            return 301 /lab;
         }
 
         location /account/settings {
-            return 301 /#/settings;
+            return 301 /settings;
         }
 
         location /home {
             return 301 /;
         }
 
-        location /privacy {
-            return 301 /#/privacy;
-        }
-
         location /team {
-            return 301 /#/about/team;
+            return 301 /about/team;
         }
 
         location /about {
-            return 301 /#/about;
+            return 301 /about;
         }
 
         location ~* /project/.* {
-            return 301 /#/projects;
+            return 301 /projects;
         }
 
         location /education {
-            return 301 /#/about/education;
+            return 301 /about/education;
         }
 
         location /contact {
-            return 301 /#/about/contact;
+            return 301 /about/contact;
         }
 
-        include /etc/nginx/proxy.conf;
+        include /etc/nginx/hashless-proxy.conf;
     }
 
     server {


### PR DESCRIPTION
I think this should handle a zooniverse.org that doesn't use the hash-fragment. 

The redirecting to the /user and /api routes is handled at a different layer right @astopy ?