### PR TITLE
edit Arizona BatWatch redirect

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -510,7 +510,7 @@ server {
 server {
     include /etc/nginx/ssl.default.conf;
     server_name arizonabatwatch.org www.arizonabatwatch.org;
-    return 301 https://www.zooniverse.org/projects/zooniverse/arizona-batwatch/;
+    return 301 https://www.zooniverse.org/projects/zooniverse/arizona-batwatch;
 }
 
 server {


### PR DESCRIPTION
Fixes inconsistent project background image between:
- expected - https://www.zooniverse.org/projects/zooniverse/arizona-batwatch
- misaligned (current redirect) - https://www.zooniverse.org/projects/zooniverse/arizona-batwatch/

The `/` at the end of the current redirect causes the project home background image to align itself as if not on the project home due to the following PFE code that compares the `location.pathname` to a `projectPath` based on the `slug` stored with the project that doesn't include a final `/` character:
- [PFE creating urls to compare](https://github.com/zooniverse/Panoptes-Front-End/blob/master/app/pages/project/project-page.cjsx#L119-L120)
- [PFE sizing background based on expected and actual urls](https://github.com/zooniverse/Panoptes-Front-End/blob/master/app/pages/project/project-page.cjsx#L138)