### PR TITLE
remove slash in media location

### DIFF
--- a/sites/lab.zooniverse.org.conf
+++ b/sites/lab.zooniverse.org.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/lab.zooniverse.org/$uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/lab.zooniverse.org$uri;
 
         resolver 8.8.8.8;
 


### PR DESCRIPTION
lab.zooniverse.org errors on loading images, I think due to extra slash in location regex for misc files, but please confirm.