### PR TITLE
Allow AntiSlaveryManuscripts.org to serve font files

### DIFF
--- a/sites/www.antislaverymanuscripts.org.conf
+++ b/sites/www.antislaverymanuscripts.org.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.antislaverymanuscripts.org$uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.antislaverymanuscripts.org$uri;
 
         resolver 8.8.8.8;
 

--- a/sites/www.antislaverymanuscripts.org.conf
+++ b/sites/www.antislaverymanuscripts.org.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.antislaverymanuscripts.org$uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.antislaverymanuscripts.org$uri;
 
         resolver 8.8.8.8;
 


### PR DESCRIPTION
## PR Overview
- This is related to https://github.com/zooniverse/liberating-the-liberator/issues/87
- Currently, antislaverymanuscripts.org doesn't serve the custom font files used by the website. This PR should (?) allow the files to be served.
- The specific file we're trying to serve, incidentally, is: https://www.antislaverymanuscripts.org/AbrahamLincoln.woff
- Additionally, this PR also removes what appears to be a redundant `ico` value, unless duplicate entries are some how necessary?
- Additionally, this PR also removes what appears to be a redundant `ico` value, unless duplicate entries are some how necessary?

### Status
This PR is now ready for review, but does not require high priority - it addresses a visual/design issue, not a core functionality issue.  👌 