### PR TITLE
Add config for www.ScribesOfTheCairoGeniza.org

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -637,6 +637,6 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name scribesofthecairogeniza.org www.scribesofthecairogeniza.org;
-    return 301 https://www.zooniverse.org/projects/judaicadh/scribes-of-the-cairo-geniza;
+    server_name scribesofthecairogeniza.org;
+    return 301 https://www.scribesofthecairogeniza.org;
 }

--- a/sites/www.scribesofthecairogeniza.org.conf
+++ b/sites/www.scribesofthecairogeniza.org.conf
@@ -1,0 +1,21 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name www.scribesofthecairogeniza.org;
+
+    location ~ \.(js|css)$ {
+        resolver 8.8.8.8;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.scribesofthecairogeniza.org$uri?$query_string;
+        include /etc/nginx/proxy-headers.conf;
+    }
+
+    location / {
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.scribesofthecairogeniza.org$uri;
+
+        resolver 8.8.8.8;
+
+        # This is a hack to get nginx to discard the uri in the proxy request
+        set $uri_path "www.scribesofthecairogeniza.org/";
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$uri_path;
+        include /etc/nginx/proxy-headers.conf;
+    }
+}


### PR DESCRIPTION
## PR Overview
This PR adds config details that allows the domain name `www.ScribesOfTheCairoGeniza.org` to serve a custom front end for the titular project.

- This setup is similar to `www.antislaverymanuscripts.org`, which is used as a configuration template.

### Minor Notes
- Apologies for the confusion; Scribes of the Cairo Geniza has two workflows, the first which uses the PFE, the second which uses a CFE. The latter is which the domain name should point to. 
- Additional domain names (e.g. `scribesofthecairogeniZAH.org`) may be requested in the future, but can be ignored for now.

### Status
Ready for review! 👍 