### PR TITLE
Enable JSON subjects in the PFE dev/classifier

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -61,7 +61,7 @@ server {
     }
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$host$uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|json)$ https://static.zooniverse.org/$host$uri;
 
         resolver 8.8.8.8;
         if ($request_method = GET) {


### PR DESCRIPTION
Required for https://github.com/zooniverse/Panoptes-Front-End/pull/4270

Added JSON to zooniverse statics allowed urls for dev/classifier locations, which will (hopefully?) allow a frame with a JSON location in the dev/classifier.