### PR TITLE
Allow Scribes of the Cairo Geniza to serve .txt files

### DIFF
--- a/sites/www.scribesofthecairogeniza.org.conf
+++ b/sites/www.scribesofthecairogeniza.org.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.scribesofthecairogeniza.org$uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.scribesofthecairogeniza.org$uri;
 
         resolver 8.8.8.8;
 


### PR DESCRIPTION
## PR Overview
This PR allows `https://www.scribesofthecairogeniza.org/` to serve `.txt` files, specifically for the purpose of serving a `robots.txt` file, to manage how the currently-in-development website is being indexed on Google before its full launch.

Please see https://github.com/zooniverse/scribes-of-the-cairo-geniza/pull/58 for implementation details on the app/front-end side of things.

### Status
I'm going to merge this and monitor what happens, at least for the next half hour. I don't expect side effects on any Zooniverse website, other that Scribes of the Cairo Geniza.