### PR TITLE
add penguin watch redirect to zooniverse site

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -646,3 +646,16 @@ server {
     server_name supernovasighting.org www.supernovasighting.org;
     return 301 https://www.zooniverse.org/projects/skymap/supernova-sighting;
 }
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name penguinwatch.org www.penguinwatch.org;
+
+    location /subjects/ {
+        return 301 https://static.zooniverse.org/$host$uri;
+    }
+
+    location / {
+        return 301 https://www.zooniverse.org/projects/penguintom79/penguin-watch;
+    }
+}


### PR DESCRIPTION
redirect the old penguin watch site to new zooniverse.org project but leave old talk and subjects still working.