### PR TITLE
penguin watch allow old api proxy paths

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -646,16 +646,3 @@ server {
     server_name supernovasighting.org www.supernovasighting.org;
     return 301 https://www.zooniverse.org/projects/skymap/supernova-sighting;
 }
-
-server {
-    include /etc/nginx/ssl.default.conf;
-    server_name penguinwatch.org www.penguinwatch.org;
-
-    location /subjects/ {
-        return 301 https://static.zooniverse.org/$host$uri;
-    }
-
-    location / {
-        return 301 https://www.zooniverse.org/projects/penguintom79/penguin-watch;
-    }
-}

--- a/sites/penguinwatch.org.conf
+++ b/sites/penguinwatch.org.conf
@@ -1,0 +1,27 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name penguinwatch.org www.penguinwatch.org;
+
+    include /etc/nginx/api-proxy.conf;
+
+    location /subjects/ {
+        return 301 https://static.zooniverse.org/$host$uri;
+    }
+
+    location / {
+        return 301 https://www.zooniverse.org/projects/penguintom79/penguin-watch;
+    }
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name old.penguinwatch.org;
+
+    include /etc/nginx/api-proxy.conf;
+
+    location / {
+        resolver 8.8.8.8;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.penguinwatch.org$uri?$query_string;
+        include /etc/nginx/proxy-headers.conf;
+    }
+}


### PR DESCRIPTION
setup penguin watch to respect the api proxy paths to keep talk working and setup a way to run old PW on old subdomain