### PR TITLE
Add NfN Field Book prod and preview configs

### DIFF
--- a/sites/field-book-preview.notesfromnature.org.conf
+++ b/sites/field-book-preview.notesfromnature.org.conf
@@ -1,0 +1,21 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name field-book-preview.notesfromnature.org;
+
+    location ~ \.(js|css)$ {
+        resolver 8.8.8.8;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/field-book-preview.notesfromnature.org$uri?$query_string;
+        include /etc/nginx/proxy-headers.conf;
+    }
+
+    location / {
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/field-book-preview.notesfromnature.org$uri;
+
+        resolver 8.8.8.8;
+
+        # This is a hack to get nginx to discard the uri in the proxy request
+        set $uri_path "field-book-preview.notesfromnature.org/";
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$uri_path;
+        include /etc/nginx/proxy-headers.conf;
+    }
+}

--- a/sites/field-book.notesfromnature.org.conf
+++ b/sites/field-book.notesfromnature.org.conf
@@ -1,0 +1,21 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name field-book.notesfromnature.org;
+
+    location ~ \.(js|css)$ {
+        resolver 8.8.8.8;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/field-book.notesfromnature.org$uri?$query_string;
+        include /etc/nginx/proxy-headers.conf;
+    }
+
+    location / {
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/field-book.notesfromnature.org$uri;
+
+        resolver 8.8.8.8;
+
+        # This is a hack to get nginx to discard the uri in the proxy request
+        set $uri_path "field-book.notesfromnature.org/";
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$uri_path;
+        include /etc/nginx/proxy-headers.conf;
+    }
+}


### PR DESCRIPTION
Adds configs for the new [Notes from Nature Field Book](https://github.com/zooniverse/notes-from-nature-field-book).

field-book.notesfromnature.org - is the production/master build
field-book-preview.notesfromnature.org - will be used for testing or previewing changes

It's unlikely there'll be any need to preview multiple branches, so it's ok to have the one destination (field-book-preview.notesfromnature.org) for any branch we'd like to preview. Also noting field-book-preview will point to Panoptes production because Create-React-App [doesn't allow manual editing of Node ENV variables](https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables), which is also ok.