### PR TITLE
add explicit stats server configuration block

### DIFF
--- a/sites/standalone-swarm.conf
+++ b/sites/standalone-swarm.conf
@@ -31,8 +31,6 @@ server {
         portainer.zooniverse.org
         sendy.zooniverse.org
         ses-bounces.zooniverse.org
-        stats.zooniverse.org
-        stats-staging.zooniverse.org
         talk.ancientlives.org
         talk.andromedaproject.org
         talk.batdetective.org
@@ -56,6 +54,41 @@ server {
         resolver 172.17.0.2;
         proxy_pass $standalone_swarm_uri;
         proxy_set_header Host $host.web-hosts;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_buffer_size   128k;
+        proxy_buffers   4 256k;
+        proxy_busy_buffers_size   256k;
+    }
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+
+    server_name
+        stats.zooniverse.org
+        stats-staging.zooniverse.org
+    ;
+
+    set $standalone_swarm_uri "https://standalone-swarm.zooniverse.org";
+    location / {
+        # Put the URL in a variable to force re-resolution of the DNS name
+        # Otherwise nginx will cache it indefinitely and it'll break if IPs change
+        resolver 172.17.0.2;
+        proxy_pass $standalone_swarm_uri;
+        proxy_set_header Host $host.web-hosts;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_buffer_size   128k;
+        proxy_buffers   4 256k;
+        proxy_busy_buffers_size   256k;
+    }
+    
+    set $standalone_swarm_uri "https://standalone-swarm.zooniverse.org";
+    location /graphql {
+        # Put the URL in a variable to force re-resolution of the DNS name
+        # Otherwise nginx will cache it indefinitely and it'll break if IPs change
+        resolver 172.17.0.2;
+        proxy_pass $standalone_swarm_uri;
+        proxy_set_header Host graphql.$host.web-hosts;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_buffer_size   128k;
         proxy_buffers   4 256k;

--- a/sites/standalone-swarm.conf
+++ b/sites/standalone-swarm.conf
@@ -88,7 +88,7 @@ server {
         # Otherwise nginx will cache it indefinitely and it'll break if IPs change
         resolver 172.17.0.2;
         proxy_pass $standalone_swarm_uri;
-        proxy_set_header Host graphql.$host.web-hosts;
+        proxy_set_header Host graphql-$host.web-hosts;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_buffer_size   128k;
         proxy_buffers   4 256k;

--- a/sites/standalone-swarm.conf
+++ b/sites/standalone-swarm.conf
@@ -70,25 +70,24 @@ server {
     ;
 
     set $standalone_swarm_uri "https://standalone-swarm.zooniverse.org";
-    location / {
-        # Put the URL in a variable to force re-resolution of the DNS name
-        # Otherwise nginx will cache it indefinitely and it'll break if IPs change
-        resolver 172.17.0.2;
-        proxy_pass $standalone_swarm_uri;
-        proxy_set_header Host $host.web-hosts;
-        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
-        proxy_buffer_size   128k;
-        proxy_buffers   4 256k;
-        proxy_busy_buffers_size   256k;
-    }
-    
-    set $standalone_swarm_uri "https://standalone-swarm.zooniverse.org";
     location /graphql {
         # Put the URL in a variable to force re-resolution of the DNS name
         # Otherwise nginx will cache it indefinitely and it'll break if IPs change
         resolver 172.17.0.2;
         proxy_pass $standalone_swarm_uri;
         proxy_set_header Host graphql-$host.web-hosts;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_buffer_size   128k;
+        proxy_buffers   4 256k;
+        proxy_busy_buffers_size   256k;
+    }
+    
+    location / {
+        # Put the URL in a variable to force re-resolution of the DNS name
+        # Otherwise nginx will cache it indefinitely and it'll break if IPs change
+        resolver 172.17.0.2;
+        proxy_pass $standalone_swarm_uri;
+        proxy_set_header Host $host.web-hosts;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_buffer_size   128k;
         proxy_buffers   4 256k;


### PR DESCRIPTION
allow stats.zooniverse.org to switch internal apps (swarm container) based on the path: 
- no path will resolve to the current `stats.zooniverse.org.web-hosts` swarm container service
- `/graphql` path with resolve to the new `graphql-stats.zooniverse.org.web-hosts`