### PR TITLE
add graphql rewrite

### DIFF
--- a/sites/standalone-swarm.conf
+++ b/sites/standalone-swarm.conf
@@ -70,10 +70,16 @@ server {
     ;
 
     set $standalone_swarm_uri "https://standalone-swarm.zooniverse.org";
-    location /graphql {
+    location ^/graphql {
         # Put the URL in a variable to force re-resolution of the DNS name
         # Otherwise nginx will cache it indefinitely and it'll break if IPs change
         resolver 172.17.0.2;
+        
+        if ($request_method = GET ) {
+            # remove the graphql path suffix 
+            rewrite ^/graphql / break;
+        }
+        
         proxy_pass $standalone_swarm_uri;
         proxy_set_header Host graphql-$host.web-hosts;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;


### PR DESCRIPTION
rewrite get requests for `stats.zooniverse.org/graphql` path. This will allow the rails default route / health check to be available to the outside world while still allowing post requests to `/graphql` end points as per the rails routes
https://github.com/zooniverse/zoo-stats-api-graphql/blob/905e2b0c46e61c028686aeb1a9e1afc8a512dfec/config/routes.rb#L4