### PR TITLE
allow HEAD requests for zooniverse pages

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -87,6 +87,6 @@ server {
         if ($request_method = POST) {
            proxy_pass             https://panoptes.zooniverse.org/$uri;
         }
-                include /etc/nginx/proxy-headers.conf;
+        include /etc/nginx/proxy-headers.conf;
     }
 }

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -81,12 +81,12 @@ server {
         rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|json)$ https://static.zooniverse.org/$host$uri;
 
         resolver 8.8.8.8;
-        if ($request_method = GET) {
+        if ($request_method ~ ^(GET|HEAD)$) {
            proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host/;
         }
         if ($request_method = POST) {
            proxy_pass             https://panoptes.zooniverse.org/$uri;
         }
-        include /etc/nginx/proxy-headers.conf;
+                include /etc/nginx/proxy-headers.conf;
     }
 }


### PR DESCRIPTION
I found some errors in nginx static server logs. the changes should allow HEAD req's through to the s3 bucket paths - though i'm not sure how it will help serve them properly as those full paths don't resolve via s3, i think i'm not understanding how the proxy service is working.
```
) "/usr/share/nginx/html/projects/klmasters/galaxy-zoo-3d" failed (2: No such file or directory), client: 34.195.252.238, server: www.zooniverse.org, request: "HEAD /projects/klmasters/galaxy-zoo-3d HTTP/1.1", host: "www.zooniverse.org"
```