### PR TITLE
Updated PH config for TESS launch

### DIFF
--- a/sites/planethunters.org.conf
+++ b/sites/planethunters.org.conf
@@ -1,6 +1,6 @@
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name www.planethunters.org;
+    server_name planethunters.org www.planethunters.org;
 
     location / {
         return 301 https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess;

--- a/sites/planethunters.org.conf
+++ b/sites/planethunters.org.conf
@@ -2,6 +2,8 @@ server {
     include /etc/nginx/ssl.default.conf;
     server_name planethunters.org www.planethunters.org;
 
+    include /etc/nginx/api-proxy.conf;
+
     location / {
         return 301 https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess;
     }

--- a/sites/planethunters.org.conf
+++ b/sites/planethunters.org.conf
@@ -19,8 +19,6 @@ server {
     location /authors {
         return 301 http://old.planethunters.org$uri;
     }
-
-    include /etc/nginx/proxy.conf;
 }
 
 server {

--- a/sites/standalone-swarm.conf
+++ b/sites/standalone-swarm.conf
@@ -75,12 +75,12 @@ server {
         # Put the URL in a variable to force re-resolution of the DNS name
         # Otherwise nginx will cache it indefinitely and it'll break if IPs change
         resolver 172.17.0.2;
-        
+
         if ($request_method = GET ) {
-            # remove the graphql path suffix 
+            # remove the graphql path suffix
             rewrite ^/graphql / break;
         }
-        
+
         proxy_pass $standalone_swarm_uri;
         proxy_set_header Host graphql-$host.web-hosts;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
@@ -88,7 +88,7 @@ server {
         proxy_buffers   4 256k;
         proxy_busy_buffers_size   256k;
     }
-    
+
     location / {
         # Put the URL in a variable to force re-resolution of the DNS name
         # Otherwise nginx will cache it indefinitely and it'll break if IPs change

--- a/sites/www.planethunters.org.conf
+++ b/sites/www.planethunters.org.conf
@@ -23,7 +23,7 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name old.planethunters.org;
+    server_name kepler.planethunters.org;
 
     include /etc/nginx/api-proxy.conf;
 

--- a/sites/www.planethunters.org.conf
+++ b/sites/www.planethunters.org.conf
@@ -2,13 +2,22 @@ server {
     include /etc/nginx/ssl.default.conf;
     server_name www.planethunters.org;
 
-    location /PH6 {
-        return 301 http://old.planethunters.org/PH6;
-    }
-
-    location /authors {
-        return 301 http://old.planethunters.org$uri;
+    location / {
+        return 301 https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess;
     }
 
     include /etc/nginx/proxy.conf;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name old.planethunters.org;
+
+    include /etc/nginx/api-proxy.conf;
+
+    location / {
+        resolver 8.8.8.8;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.planethunters.org$uri?$query_string;
+        include /etc/nginx/proxy-headers.conf;
+    }
 }

--- a/sites/www.planethunters.org.conf
+++ b/sites/www.planethunters.org.conf
@@ -6,6 +6,18 @@ server {
         return 301 https://www.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess;
     }
 
+    location /subjects/ {
+        return 301 https://static.zooniverse.org/$host$uri;
+    }
+
+    location /PH6 {
+        return 301 http://old.planethunters.org/PH6;
+    }
+
+    location /authors {
+        return 301 http://old.planethunters.org$uri;
+    }
+
     include /etc/nginx/proxy.conf;
 }
 


### PR DESCRIPTION
* 301 redirect to new TESS page
* Removed vestigial /PH and /authors redirects
* Added server block for old static site at old.planethunters.org

? 
* How do we wire up the existing (non-PFE) Talk board?
* ~How does this get deployed?~ A merge to master will rebuild the image (via jenkinsfile)
* ~Why are the CI checks failing?~ Unnecessary proxy.conf include
* Do the rules in the redirects conf need adjusting? The beta. link just goes to the (old) static site, for instance.