### PR TITLE
Add Content-Security-Policy and allow Crick

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 static
 ======
+
+An nginx caching proxy (mostly) for serving static sites from S3.
+
+Run it locally with Docker:
+
+```
+docker-compose build
+docker-compose up
+```
+
+And access it at http://localhost:8080/.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  imgproc:
+    image: zooniverse/image-processing
+
+  static:
+    build:
+      context:  ./
+      dockerfile: Dockerfile
+    links:
+      - imgproc:imgproc
+    ports:
+      - "8080:80"

--- a/nginx-proxy-headers.conf
+++ b/nginx-proxy-headers.conf
@@ -3,7 +3,8 @@ add_header 'Access-Control-Allow-Credentials' 'true';
 add_header 'Access-Control-Allow-Methods' 'GET';
 add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
 add_header 'X-Content-Type-Options' 'nosniff';
-add_header 'X-Frame-Options' 'SAMEORIGIN';
+add_header 'Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+add_header 'X-Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
 add_header 'X-XSS-Protection' '1; mode=block';
 
 proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;

--- a/sites/star.pfe-preview.zooniverse.org.conf
+++ b/sites/star.pfe-preview.zooniverse.org.conf
@@ -1,4 +1,5 @@
 server {
+    set $csp_whitelist "zooniverse.org *.zooniverse.org *.mturk.com";
     include /etc/nginx/ssl.default.conf;
     server_name "~^(?P<subdomain>.*)\.pfe-preview\.zooniverse\.org$";
 
@@ -7,16 +8,7 @@ server {
         proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/panoptes-front-end/$subdomain$uri?$query_string;
         proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
 
-        # Testing switch from X-Frame-Options to Content-Security-Policy
-        # include /etc/nginx/proxy-headers.conf;
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Credentials' 'true';
-        add_header 'Access-Control-Allow-Methods' 'GET';
-        add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-        add_header 'Content-Security-Policy' "frame-ancestors 'self' zooniverse.org *.zooniverse.org *.mturk.com";
-        add_header 'X-Content-Security-Policy' "frame-ancestors 'self' zooniverse.org *.zooniverse.org *.mturk.com";
-        add_header 'X-Content-Type-Options' 'nosniff';
-        add_header 'X-XSS-Protection' '1; mode=block';
+        include /etc/nginx/proxy-headers.conf;
     }
 
     location / {
@@ -25,16 +17,7 @@ server {
         resolver 8.8.8.8;
         proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/panoptes-front-end/$subdomain/;
 
-        # Testing switch from X-Frame-Options to Content-Security-Policy
-        # include /etc/nginx/proxy-headers.conf;
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Credentials' 'true';
-        add_header 'Access-Control-Allow-Methods' 'GET';
-        add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-        add_header 'Content-Security-Policy' "frame-ancestors 'self' zooniverse.org *.zooniverse.org *.mturk.com";
-        add_header 'X-Content-Security-Policy' "frame-ancestors 'self' zooniverse.org *.zooniverse.org *.mturk.com";
-        add_header 'X-Content-Type-Options' 'nosniff';
-        add_header 'X-XSS-Protection' '1; mode=block';
+        include /etc/nginx/proxy-headers.conf;
     }
 }
 

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -1,5 +1,5 @@
 server {
-    set $csp_whitelist "zooniverse.org *.zooniverse.org";
+    set $csp_whitelist "zooniverse.org *.zooniverse.org webservices.crick.ac.uk CLVD0-WS-U-T-29.thecrick.org";
     include /etc/nginx/ssl.default.conf;
     server_name www.zooniverse.org;
 

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -1,4 +1,5 @@
 server {
+    set $csp_whitelist "zooniverse.org *.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
     server_name www.zooniverse.org;
 


### PR DESCRIPTION
This sets a Content-Security-Policy for everything by default, removing X-Frame-Options. `self` (equivalent to `SAMEORIGIN`) is allowed by default. The `$csp_whitelist` variable can be used to add extra domains.