### PR TITLE
remove prn-maps api from swarm

### DIFF
--- a/sites/swarm19a.conf
+++ b/sites/swarm19a.conf
@@ -19,7 +19,6 @@ server {
         hubble.galaxyzoo.org
         interventions-gateway-staging.zooniverse.org
         interventions-gateway.zooniverse.org
-        maps-api.planetaryresponsenetwork.org
         old.oldweather.org
         old.planethunters.org
         oldtalk.planethunters.org


### PR DESCRIPTION
don't proxy this to the upstream swarm, proxy it to the microservices k8 cluster instead