### PR TITLE
Move whaling.oldweather.org to Kubernetes

### DIFF
--- a/sites/microservices.conf
+++ b/sites/microservices.conf
@@ -18,6 +18,7 @@ server {
         talk.batdetective.org
         talk.seafloorexplorer.org
         talk.setilive.org
+        whaling.oldweather.org
         www.setilive.org
     ;
 

--- a/sites/swarm19a.conf
+++ b/sites/swarm19a.conf
@@ -17,8 +17,6 @@ server {
         interventions-gateway-staging.zooniverse.org
         interventions-gateway.zooniverse.org
         passbolt.zooniverse.org
-        visualize.galaxyzoo.org
-        whaling.oldweather.org
         www.measuringtheanzacs.org
         www.zooteach.org
     ;


### PR DESCRIPTION
Also remove visualize.galaxyzoo.org, which is no longer being proxied.