### PR TITLE
[WIP] custom project redirect for a launched project with links in the wild

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -71,6 +71,10 @@ server {
         return 301 /about/contact;
     }
 
+    location ~* ^/projects/meredithspalmer/(cedar-creek-eyes-on-the-wild/?)(.*?)\/?$ {
+        return 301 /projects/forestis/$1$2$is_args$query_string;
+    }
+
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
         proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$uri?$query_string;


### PR DESCRIPTION
**DO NOT MERGE YET ** project ownership transfer needs to take place.

https://www.zooniverse.org/projects/meredithspalmer/cedar-creek-eyes-on-the-wild

The launched project with links in the wild needs to transfer the owner and thus change the URL. This redirect will handle any path suffixes and query params.

Tested locally with the following results:
```
$ curl -I --compressed --header "Host: www.zooniverse.org" localhost:8080/projects/meredithspalmer/cedar-creek-eyes-on-the-wild/talk/2176/949783?comment=1568387
HTTP/1.1 301 Moved Permanently
Server: nginx/1.4.6 (Ubuntu)
Date: Wed, 03 Apr 2019 15:32:55 GMT
Content-Type: text/html
Content-Length: 193
Location: http://www.zooniverse.org/projects/forestis/cedar-creek-eyes-on-the-wild/talk/2176/949783?comment=1568387
Connection: keep-alive

$ curl -I --compressed --header "Host: www.zooniverse.org" localhost:8080/projects/meredithspalmer/cedar-creek-eyes-on-the-wild/classify
HTTP/1.1 301 Moved Permanently
Server: nginx/1.4.6 (Ubuntu)
Date: Wed, 03 Apr 2019 15:33:01 GMT
Content-Type: text/html
Content-Length: 193
Location: http://www.zooniverse.org/projects/forestis/cedar-creek-eyes-on-the-wild/classify
Connection: keep-alive
```