### PR TITLE
Clean up education-api entries

### DIFF
--- a/sites/standalone-swarm.conf
+++ b/sites/standalone-swarm.conf
@@ -12,7 +12,6 @@ server {
     include /etc/nginx/ssl.default.conf;
 
     server_name
-        education-api.zooniverse.org
         faas.zooniverse.org
         mechanical-staging.zooniverse.org
         mechanical.zooniverse.org

--- a/sites/swarm19a.conf
+++ b/sites/swarm19a.conf
@@ -13,7 +13,6 @@ server {
 
     server_name
         caesar.zooniverse.org
-        education-api-staging.zooniverse.org
         interventions-gateway-staging.zooniverse.org
         interventions-gateway.zooniverse.org
     ;


### PR DESCRIPTION
These have been moved to Kubernetes and no longer need to be proxied.