### PR TITLE
Remove setilive from microservices cluster and update redirect

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -360,8 +360,8 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name setilive.org frank.setilive.org marv.setilive.org;
-    return 301 http://www.setilive.org$request_uri;
+    server_name setilive.org
+    return 301 https://www.setilive.org$request_uri;
 }
 
 server {

--- a/sites/microservices.conf
+++ b/sites/microservices.conf
@@ -18,7 +18,6 @@ server {
         talk.batdetective.org
         talk.seafloorexplorer.org
         talk.setilive.org
-        www.setilive.org
         www.zooteach.org
     ;
 


### PR DESCRIPTION
Goodnight, SETI Live. I created a new bucket in zooniverse-static with the contents of the retirement page uploaded, so when this goes through it should start serving from there.