### PR TITLE
Add HTTPS redirects for microplants.* sites

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -37,7 +37,7 @@ server {
 server {
     include /etc/nginx/ssl.default.conf;
     server_name microplants.zooniverse.org microplants.fieldmuseum.org microplants.org;
-    return 301 https://www.microplants.zooniverse.org$request_uri;
+    return 301 https://microplants.zooniverse.org$request_uri;
 }
 
 server {

--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -42,6 +42,12 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
+    server_name talk.microplants.org;
+    return 301 http://microplantstalk.zooniverse.org$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
     server_name planetfour.org;
     return 301 http://www.planetfour.org$request_uri;
 }

--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -36,6 +36,12 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
+    server_name microplants.zooniverse.org microplants.fieldmuseum.org microplants.org;
+    return 301 https://www.microplants.zooniverse.org$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
     server_name planetfour.org;
     return 301 http://www.planetfour.org$request_uri;
 }


### PR DESCRIPTION
Sets up an HTTPS redirect to https://microplants.zooniverse.org from

* microplants.zooniverse.org 
* microplants.fieldmuseum.org 
* microplants.org, which is currently ALIAS'd to `http-frontend-1695085103.us-east-1.elb.amazonaws.com`, though it seems like it's just falling back to a missing S3 bucket right now.

This should serve all three sites from the microplants.zooniverse.org bucket.