### PR TITLE
Fix Microplants redirect and talk

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -36,7 +36,7 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name microplants.zooniverse.org microplants.fieldmuseum.org microplants.org;
+    server_name microplants.fieldmuseum.org microplants.org;
     return 301 https://microplants.zooniverse.org$request_uri;
 }
 

--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -41,6 +41,7 @@ server {
 }
 
 server {
+    include /etc/nginx/api-proxy.conf;
     include /etc/nginx/ssl.default.conf;
     server_name talk.microplants.org;
     return 301 http://microplantstalk.zooniverse.org$request_uri;


### PR DESCRIPTION
Including microplants.zooniverse.org in the server name seems to break serving the static site from S3. 

Also added the API proxy conf to the block to fix talk.