### PR TITLE
Add more redirects for inactive WordPress blogs

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -425,6 +425,36 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
+    server_name blog.batdetective.org;
+    return 301 https://batdetect.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name blog.sciencegossip.org;
+    return 301 https://sciencegossipblog.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name blog.orchidobservers.org;
+    return 301 https://orchidobservers.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name blog.condorwatch.org;
+    return 301 https://condorzoo.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name blog.decodingthecivilwar.org;
+    return 301 https://decodingthecivilwar.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
     server_name planetaryresponsenetwork.org planetaryresponsenetwork.net planetaryresponsenetwork.com www.planetaryresponsenetwork.org www.planetaryresponsenetwork.net www.planetaryresponsenetwork.com;
     return 301 https://www.zooniverse.org/projects/vrooje/planetary-response-network-and-rescue-global-caribbean-storms-2017;
 }


### PR DESCRIPTION
Continuing an effort started in https://github.com/zooniverse/static/pull/90, here I add redirects for 5 more inactive / retired projects: Bat Detective, Science Gossip, Orchid Observers, Condor Watch, Decoding the Civil War.

Domain mapping via WordPress for these sites are currently paid up for up to the next year, but on the WordPress Admin page I've cancelled the domain mapping subscriptions, assigned the non-"blog.XXX.org" domain as primary, and added the redirects to the nginx config file.