### PR TITLE
Add redirect + api-proxy for Notes from Nature Talk

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -188,8 +188,12 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
+    include /etc/nginx/api-proxy.conf;
     server_name notesfromnature.org www.notesfromnature.org;
-    return 301 https://www.zooniverse.org/organizations/md68135/notes-from-nature;
+
+    location / {
+        return 301 https://www.zooniverse.org/organizations/md68135/notes-from-nature;
+    }
 }
 
 server {


### PR DESCRIPTION
Fixes issue of old Notes from Nature Talk posts loading, as reported in [Freshdesk Ticket 1162](https://zooniverse.freshdesk.com/a/tickets/1162).

@adammcmaster -- I think this is the fix, but please take a look.