### PR TITLE
Add /subjects/ loc block for old Talk subjects

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -191,6 +191,10 @@ server {
     include /etc/nginx/api-proxy.conf;
     server_name notesfromnature.org www.notesfromnature.org;
 
+    location /subjects/ {
+        return 301 https://static.zooniverse.org/$host$uri;
+    }
+
     location / {
         return 301 https://www.zooniverse.org/organizations/md68135/notes-from-nature;
     }


### PR DESCRIPTION
Building on from https://github.com/zooniverse/static/pull/103, fixes broken image links in old NfN Talk.

Now the server block directly copies the form used by Chimp & See project (see https://github.com/zooniverse/static/pull/97 and https://github.com/zooniverse/static/pull/99).