### PR TITLE
Remove fe-*.preview.zooniverse.org config

### DIFF
--- a/sites/star.preview.zooniverse.org.conf
+++ b/sites/star.preview.zooniverse.org.conf
@@ -1,27 +1,5 @@
 server {
     include /etc/nginx/ssl.default.conf;
-
-    # NOTE: If you're looking for the config for frontend.preview.zooniverse.org
-    #       it's configured in Route 53 to point directly at CloudFront rather
-    #       than being configured here.
-    server_name fe-project.preview.zooniverse.org fe-content-pages.preview.zooniverse.org;
-
-    set $upstream_uri "https://microservices.zooniverse.org";
-    location / {
-        # Put the URL in a variable to force re-resolution of the DNS name
-        # Otherwise nginx will cache it indefinitely and it'll break if IPs change
-        resolver 172.17.0.2;
-        proxy_pass $upstream_uri;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
-        proxy_buffer_size   128k;
-        proxy_buffers   4 256k;
-        proxy_busy_buffers_size   256k;
-    }
-}
-
-server {
-    include /etc/nginx/ssl.default.conf;
     server_name "~^(?P<subdomain>.*)\.preview\.zooniverse\.org$";
 
     include /etc/nginx/api-proxy.conf;


### PR DESCRIPTION
This is now pointed directly to Azure in DNS.