### PR TITLE
Remove legacy Rails apps

### DIFF
--- a/sites/microservices.conf
+++ b/sites/microservices.conf
@@ -12,12 +12,6 @@ server {
     include /etc/nginx/ssl.default.conf;
 
     server_name
-        oldtalk.planethunters.org
-        talk.ancientlives.org
-        talk.andromedaproject.org
-        talk.batdetective.org
-        talk.seafloorexplorer.org
-        talk.setilive.org
         www.zooteach.org
     ;
 


### PR DESCRIPTION
These are now served directly by Azure