### PR TITLE
Remove Crick domains from zooniverse.org CSP

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -1,5 +1,5 @@
 server {
-    set $csp_whitelist "zooniverse.org *.zooniverse.org webservices.crick.ac.uk CLVD0-WS-U-T-29.thecrick.org";
+    set $csp_whitelist "zooniverse.org *.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
     server_name www.zooniverse.org;
 


### PR DESCRIPTION
This was added for an exhibition which has now ended.