### PR TITLE
Update P4 nginx config

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -49,12 +49,6 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name planetfour.org;
-    return 301 http://www.planetfour.org$request_uri;
-}
-
-server {
-    include /etc/nginx/ssl.default.conf;
     server_name www.whale.fm talk.whale.fm whale.scientificamerican.com;
     return 301 http://whale.fm;
 }
@@ -198,12 +192,6 @@ server {
     location / {
         return 301 https://www.zooniverse.org/organizations/md68135/notes-from-nature;
     }
-}
-
-server {
-    include /etc/nginx/ssl.default.conf;
-    server_name planet4.org www.planet4.org;
-    return 301 http://planetfour.org$request_uri;
 }
 
 server {

--- a/sites/www.planetfour.org.conf
+++ b/sites/www.planetfour.org.conf
@@ -1,6 +1,6 @@
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name planetfour.org;
+    server_name www.planetfour.org planetfour.org www.planet4.org planet4.org;
 
     location /authors {
         return 301 https://authors.planetfour.org/;
@@ -16,13 +16,3 @@ server {
     }
 }
 
-server {
-    include /etc/nginx/ssl.default.conf;
-    server_name authors.planetfour.org;
-
-    location / {
-        resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/authors.planetfour.org$uri?$query_string;
-        include /etc/nginx/proxy-headers.conf;
-    }
-}

--- a/sites/www.planetfour.org.conf
+++ b/sites/www.planetfour.org.conf
@@ -1,14 +1,29 @@
 server {
     include /etc/nginx/ssl.default.conf;
     server_name www.planetfour.org;
+    include /etc/nginx/proxy.conf;
 
     location /authors {
-        return 301 https://www.planetfour.org/#/authors;
+        return 301 https://authors.planetfour.org/;
     }
 
     location /results {
-        return 301 https://www.planetfour.org/#/results;
+        return 301 https://www.zooniverse.org/projects/mschwamb/planet-four/about/results;
     }
 
-    include /etc/nginx/proxy.conf;
+
+    location / {
+        return 301 https://www.zooniverse.org/projects/mschwamb/planet-four;
+    }
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name authors.planetfour.org;
+
+    location / {
+        resolver 8.8.8.8;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/authors.planetfour.org$uri?$query_string;
+        include /etc/nginx/proxy-headers.conf;
+    }
 }

--- a/sites/www.planetfour.org.conf
+++ b/sites/www.planetfour.org.conf
@@ -1,7 +1,6 @@
 server {
     include /etc/nginx/ssl.default.conf;
     server_name planetfour.org;
-    include /etc/nginx/proxy.conf;
 
     location /authors {
         return 301 https://authors.planetfour.org/;

--- a/sites/www.planetfour.org.conf
+++ b/sites/www.planetfour.org.conf
@@ -1,6 +1,6 @@
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name www.planetfour.org;
+    server_name planetfour.org;
     include /etc/nginx/proxy.conf;
 
     location /authors {


### PR DESCRIPTION
`/results` redirects to https://www.zooniverse.org/projects/mschwamb/planet-four/about/results

`/authors` redirects to https://authors.planetfour.org, which has a second server block because there's a Cloudfront distro for the domain. This block redirects to the zooniverse-static S3 bucket `authors.planetfour.org`.

`/` redirects to the project page at https://www.zooniverse.org/projects/mschwamb/planet-four;

While planetfour.org does have its own conf file in /sites, it also has a bunch of misc rules in nginx-redirects.conf. This includes `p4authors.planetfour.org`, which currently redirects to https://www.zooniverse.org/projects/mschwamb/planet-four-terrains/about/results. Should this remain the same?

cc @lcjohnso. Resolves https://github.com/zooniverse/static/issues/117.