### PR TITLE
Remove imgproc link from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,5 @@ services:
     build:
       context:  ./
       dockerfile: Dockerfile
-    links:
-      - imgproc:imgproc
     ports:
       - "8080:80"


### PR DESCRIPTION
I missed this in #115 and it's stopping this from building.