### PR TITLE
Add SVG to Alice conf file

### DIFF
--- a/sites/alice.zooniverse.org.conf
+++ b/sites/alice.zooniverse.org.conf
@@ -9,7 +9,7 @@ server {
   }
 
   location / {
-      rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/alice.zooniverse.org$uri;
+      rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/alice.zooniverse.org$uri;
 
       resolver 8.8.8.8;
 


### PR DESCRIPTION
alice.zooniverse.org is working properly, but the default avatar SVG isn't loading on the user badge. It's also the only SVG contained in the app.