### PR TITLE
Add access to old Disk Detective Talk

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -293,8 +293,15 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
+    include /etc/nginx/api-proxy.conf;
     server_name diskdetective.org www.diskdetective.org;
-    return 301 https://www.zooniverse.org/projects/ssilverberg/disk-detective;
+
+    location /subjects/ {
+        return 301 https://static.zooniverse.org/$host$uri;
+    }
+
+    location / {
+        return 301 https://www.zooniverse.org/projects/ssilverberg/disk-detective;
 }
 
 server {

--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -302,6 +302,7 @@ server {
 
     location / {
         return 301 https://www.zooniverse.org/projects/ssilverberg/disk-detective;
+    }
 }
 
 server {


### PR DESCRIPTION
In addition to redirect, Disk Detective team has requested continued access to their old (v1) Talk. Following Chimp&See nginx example, adds api-proxy and subjects block to enable this access.