### PR TITLE
Log to stdout/stderr

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -39,6 +39,9 @@ spec:
                  value: liveness-probe
           ports:
             - containerPort: 80
+          env:
+            - name: LOG_STDOUT
+              value: true
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/nginx.conf
+++ b/nginx.conf
@@ -32,8 +32,8 @@ http {
     log_format  main  '$remote_addr $host $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" $upstream_cache_status' ;
-    access_log /var/log/static/access.log main;
-    error_log /var/log/static/error.log;
+    access_log /dev/stdout main;
+    error_log /dev/stderr;
 
     ##
     # Gzip Settings


### PR DESCRIPTION
The LOG_STDOUT variable is needed for the older zooniverse/nginx image
that this uses, to configure supervisor appropriately.

Long term we will want to switch to the newer (versioned, based on upstream)
nginx image, but we'll want to wait until AWS is torn down.