### PR TITLE
Add ingress for zooniverse.org

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,7 @@ pipeline {
       agent any
       steps {
         sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl --context azure apply --dry-run=client --record -f -"
+        sh "kubectl --context azure apply --dry-run=client --record -f kubernetes/ingress/"
       }
     }
 
@@ -75,6 +76,7 @@ pipeline {
       agent any
       steps {
         sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl --context azure apply --record -f -"
+        sh "kubectl --context azure apply --record -f kubernetes/ingress/"
       }
     }
 

--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: zooniverse-org-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - zooniverse.org
+    secretName: zooniverse-org-tls-secret
+  rules:
+  - host: zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)


### PR DESCRIPTION
In preparation for switching frontend sites over to Azure, I'm going to start adding *.zooniverse.org domains to an ingress here. I'm starting with the bare Zooniverse.org domain, and in another PR I plan to add more records which are currently being served directly by the static ELB.