### PR TITLE
Add proxy config for lists and status

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -12,9 +12,25 @@ spec:
   tls:
   - hosts:
     - zooniverse.org
+    - lists.zooniverse.org
+    - status.zooniverse.org
     secretName: zooniverse-org-tls-secret
   rules:
   - host: zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: lists.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: status.zooniverse.org
     http:
       paths:
       - backend:

--- a/sites/lists.zooniverse.org.conf
+++ b/sites/lists.zooniverse.org.conf
@@ -1,0 +1,13 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name lists.zooniverse.org;
+    set $mailman_uri "https://mailout1.zooniverse.org";
+    location / {
+        # Put the URL in a variable to force re-resolution of the DNS name
+        # Otherwise nginx will cache it indefinitely and it'll break if IPs change
+        resolver 172.17.0.2;
+        proxy_pass $mailman_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+}

--- a/sites/status.zooniverse.org.conf
+++ b/sites/status.zooniverse.org.conf
@@ -1,0 +1,13 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name status.zooniverse.org;
+    set $status_uri "https://zooniverse-359.freshstatus.io";
+    location / {
+        # Put the URL in a variable to force re-resolution of the DNS name
+        # Otherwise nginx will cache it indefinitely and it'll break if IPs change
+        resolver 172.17.0.2;
+        proxy_pass $status_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+}


### PR DESCRIPTION
These two domains are currently ALIASes for CloudFront distributions (as are many others). With all the others I'm changing them to CNAMEs for now while we move everything into Azure DNS. However, since these two domains handle email and have MX records, they can't be set up as CNAMEs. Because of that I'm getting them pointed to Azure now with A records and replacing CloudFront with an Nginx proxy.

This is probably how we'll set up most of our other domains which are currently in CloudFront, but we can come back to the rest once the DNS is migrated.