### PR TITLE
Add certificates and ingresses

### DIFF
--- a/kubernetes/ingress/condorwatch.org.yaml
+++ b/kubernetes/ingress/condorwatch.org.yaml
@@ -1,0 +1,46 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: condorwatch-org-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: condorwatch-org-tls
+  dnsNames:  
+    - condorwatch.org
+    - "*.condorwatch.org"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: condorwatch-org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - condorwatch.org
+    - "*.condorwatch.org"
+    secretName: condorwatch-org-tls
+  rules:
+  - host: condorwatch.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.condorwatch.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/ingress/operationwardiary.org.yaml
+++ b/kubernetes/ingress/operationwardiary.org.yaml
@@ -1,0 +1,46 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: operationwardiary-org-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: operationwardiary-org-tls
+  dnsNames:  
+    - operationwardiary.org
+    - "*.operationwardiary.org"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: operationwardiary-org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - operationwardiary.org
+    - "*.operationwardiary.org"
+    secretName: operationwardiary-org-tls
+  rules:
+  - host: operationwardiary.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.operationwardiary.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/ingress/planetfour.org.yaml
+++ b/kubernetes/ingress/planetfour.org.yaml
@@ -1,0 +1,46 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: planetfour-org-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: planetfour-org-tls
+  dnsNames:  
+    - planetfour.org
+    - "*.planetfour.org"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: planetfour-org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - planetfour.org
+    - "*.planetfour.org"
+    secretName: planetfour-org-tls
+  rules:
+  - host: planetfour.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.planetfour.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/ingress/planktonportal.org.yaml
+++ b/kubernetes/ingress/planktonportal.org.yaml
@@ -1,0 +1,46 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: planktonportal-org-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: planktonportal-org-tls
+  dnsNames:  
+    - planktonportal.org
+    - "*.planktonportal.org"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: planktonportal-org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - planktonportal.org
+    - "*.planktonportal.org"
+    secretName: planktonportal-org-tls
+  rules:
+  - host: planktonportal.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.planktonportal.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/ingress/setilive.org.yaml
+++ b/kubernetes/ingress/setilive.org.yaml
@@ -1,0 +1,46 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: setilive-org-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: setilive-org-tls
+  dnsNames:  
+    - setilive.org
+    - "*.setilive.org"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: setilive-org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - setilive.org
+    - "*.setilive.org"
+    secretName: setilive-org-tls
+  rules:
+  - host: setilive.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.setilive.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/ingress/spacewarps.org.yaml
+++ b/kubernetes/ingress/spacewarps.org.yaml
@@ -1,0 +1,46 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: spacewarps-org-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: spacewarps-org-tls
+  dnsNames:  
+    - spacewarps.org
+    - "*.spacewarps.org"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: spacewarps-org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - spacewarps.org
+    - "*.spacewarps.org"
+    secretName: spacewarps-org-tls
+  rules:
+  - host: spacewarps.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.spacewarps.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/ingress/wormwatchlab.org.yaml
+++ b/kubernetes/ingress/wormwatchlab.org.yaml
@@ -1,0 +1,46 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: wormwatchlab-org-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: wormwatchlab-org-tls
+  dnsNames:  
+    - wormwatchlab.org
+    - "*.wormwatchlab.org"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: wormwatchlab-org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - wormwatchlab.org
+    - "*.wormwatchlab.org"
+    secretName: wormwatchlab-org-tls
+  rules:
+  - host: wormwatchlab.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.wormwatchlab.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/ingress/zooinverse.org.yaml
+++ b/kubernetes/ingress/zooinverse.org.yaml
@@ -1,0 +1,46 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: zooinverse-org-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: zooinverse-org-tls
+  dnsNames:  
+    - zooinverse.org
+    - "*.zooinverse.org"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: zooinverse-org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - zooinverse.org
+    - "*.zooinverse.org"
+    secretName: zooinverse-org-tls
+  rules:
+  - host: zooinverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.zooinverse.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -1,3 +1,22 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: zooniverse-org-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: zooniverse-org-tls
+  dnsNames:  
+    - zooniverse.org
+    - lists.zooniverse.org
+    - status.zooniverse.org
+    - "*.staging.zooniverse.org"
+    - "*.preview.zooniverse.org"
+    - "*.pfe-preview.zooniverse.org"
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -14,7 +33,10 @@ spec:
     - zooniverse.org
     - lists.zooniverse.org
     - status.zooniverse.org
-    secretName: zooniverse-org-tls-secret
+    - "*.staging.zooniverse.org"
+    - "*.preview.zooniverse.org"
+    - "*.pfe-preview.zooniverse.org"
+    secretName: zooniverse-org-tls
   rules:
   - host: zooniverse.org
     http:
@@ -31,6 +53,27 @@ spec:
           servicePort: 80
         path: /(.*)
   - host: status.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.staging.zooniverse.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.preview.zooniverse.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.pfe-preview.zooniverse.org"
     http:
       paths:
       - backend:


### PR DESCRIPTION
Related to zooniverse/operations#424

This moves the cert and ingress definitions into this repo, grouping them into one file per domain. This doesn't change any of the definitions or add/remove anything, except zooniverse.org which gets some wildcard domains added.