### PR TITLE
Fix double slash in proxies Panoptes requests

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -89,7 +89,7 @@ server {
            proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host/;
         }
         if ($request_method = POST) {
-           proxy_pass             https://panoptes.zooniverse.org/$uri;
+           proxy_pass             https://panoptes.zooniverse.org$uri;
         }
         include /etc/nginx/proxy-headers.conf;
     }


### PR DESCRIPTION
I can only guess that the ELB in AWS used to clean these up.