### PR TITLE
Fix host name on proxy requests to panoptes

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -86,11 +86,31 @@ server {
 
         resolver 8.8.8.8;
         if ($request_method ~ ^(GET|HEAD)$) {
-           proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host/;
+            proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host/;
+            set $proxy_host_header "zooniverse-static.s3-website-us-east-1.amazonaws.com";
         }
         if ($request_method = POST) {
-           proxy_pass             https://panoptes.zooniverse.org$uri;
+            proxy_pass             https://panoptes.zooniverse.org$uri;
+            set $proxy_host_header "panoptes.zooniverse.org";
         }
-        include /etc/nginx/proxy-headers.conf;
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Methods' 'GET';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+        add_header 'X-Content-Type-Options' 'nosniff';
+        add_header 'Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+        add_header 'X-Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+        add_header 'X-XSS-Protection' '1; mode=block';
+
+        proxy_set_header       Host $proxy_host_header;
+        proxy_redirect         /$host/ /;
+        proxy_cache            STATIC;
+        proxy_cache_valid      200  1d;
+        proxy_cache_use_stale  error timeout invalid_header updating
+                    http_500 http_502 http_503 http_504;
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Credentials;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
     }
 }


### PR DESCRIPTION
This is what's causing the 405 error on unsubscribe requests. In AWS, the ELB ignored the `Host` header so this wasn't a problem before.