### PR TITLE
Use request_uri in proxy_pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,30 @@ An nginx caching proxy (mostly) for serving static sites from S3.
 
 Run it locally with Docker:
 
-```
+``` bash
 docker-compose build
 docker-compose up
 ```
 
 And access it at http://localhost:8080/.
+
+#### Testing your changes locally
+
+Use curl to test the behaviour of your target or default server block:
+
+``` bash
+curl -v -H "Host: www.zooniverse.org" http://localhost:8080/main-54f00afe77a81c4ff6b88b1e0bee34bc.css
+```
+
+Test the default - [first server block](https://github.com/zooniverse/static/blob/1572db64aaeb38d904e1a60de00e9f06871414df/nginx.conf#L69)
+
+``` bash
+# provide an unkonwn host to test the defaul server block.
+# making sure it matches path in the upstream proxy
+curl -v -H "Host: talk.sunspotter.org" http://localhost:8080/users/%E7%8E%8B%E5%8F%AF%E8%90%B1/index.html
+```
+
+Note: You must provide a host when testing locally or the implicit `localhost` host header will be used.
+
+Read more at the [Nginx request processing docs](http://nginx.org/en/docs/http/request_processing.html)
+

--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -4,6 +4,6 @@ location / {
     rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$host$uri;
 
     resolver 8.8.8.8;
-    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$uri?$query_string;
+    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;
     include /etc/nginx/proxy-headers.conf;
 }

--- a/sites/alice.zooniverse.org.conf
+++ b/sites/alice.zooniverse.org.conf
@@ -9,7 +9,7 @@ server {
   }
 
   location / {
-      rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/alice.zooniverse.org$request_uri;
+      rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/alice.zooniverse.org$uri;
 
       resolver 8.8.8.8;
 

--- a/sites/alice.zooniverse.org.conf
+++ b/sites/alice.zooniverse.org.conf
@@ -4,12 +4,12 @@ server {
 
   location ~ \.(js|css)$ {
       resolver 8.8.8.8;
-      proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/alice.zooniverse.org$uri?$query_string;
+      proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/alice.zooniverse.org$request_uri;
       include /etc/nginx/proxy-headers.conf;
   }
 
   location / {
-      rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/alice.zooniverse.org$uri;
+      rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/alice.zooniverse.org$request_uri;
 
       resolver 8.8.8.8;
 

--- a/sites/field-book-preview.notesfromnature.org.conf
+++ b/sites/field-book-preview.notesfromnature.org.conf
@@ -4,7 +4,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/field-book-preview.notesfromnature.org$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/field-book-preview.notesfromnature.org$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/field-book.notesfromnature.org.conf
+++ b/sites/field-book.notesfromnature.org.conf
@@ -4,7 +4,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/field-book.notesfromnature.org$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/field-book.notesfromnature.org$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/lab.zooniverse.org.conf
+++ b/sites/lab.zooniverse.org.conf
@@ -4,7 +4,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/lab.zooniverse.org$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/lab.zooniverse.org$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/login.zooniverse.org.conf
+++ b/sites/login.zooniverse.org.conf
@@ -4,7 +4,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/penguinwatch.org.conf
+++ b/sites/penguinwatch.org.conf
@@ -21,7 +21,7 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.penguinwatch.org$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.penguinwatch.org$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 }

--- a/sites/planethunters.org.conf
+++ b/sites/planethunters.org.conf
@@ -29,7 +29,7 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.planethunters.org$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.planethunters.org$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 }

--- a/sites/relaunch.notesfromnature.org.conf
+++ b/sites/relaunch.notesfromnature.org.conf
@@ -4,7 +4,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/relaunch.notesfromnature.org$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/relaunch.notesfromnature.org$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/spacewarps.org.conf
+++ b/sites/spacewarps.org.conf
@@ -21,7 +21,7 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/spacewarps.org$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/spacewarps.org$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 }

--- a/sites/star.lab-preview.zooniverse.org.conf
+++ b/sites/star.lab-preview.zooniverse.org.conf
@@ -4,7 +4,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/pfe-lab/$subdomain$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/pfe-lab/$subdomain$request_uri;
         proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
         include /etc/nginx/proxy-headers.conf;
     }
@@ -24,7 +24,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/pfe-lab$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/pfe-lab$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/star.pfe-preview.zooniverse.org.conf
+++ b/sites/star.pfe-preview.zooniverse.org.conf
@@ -5,7 +5,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/panoptes-front-end/$subdomain$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/panoptes-front-end/$subdomain$request_uri;
         proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
 
         include /etc/nginx/proxy-headers.conf;
@@ -27,7 +27,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/panoptes-front-end$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/panoptes-front-end$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/star.preview.zooniverse.org.conf
+++ b/sites/star.preview.zooniverse.org.conf
@@ -6,7 +6,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/$subdomain$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/$subdomain$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 
@@ -14,7 +14,7 @@ server {
         rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/preview.zooniverse.org/$subdomain$uri;
 
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/$subdomain$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/$subdomain$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 }

--- a/sites/www.antislaverymanuscripts.org.conf
+++ b/sites/www.antislaverymanuscripts.org.conf
@@ -4,7 +4,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.antislaverymanuscripts.org$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.antislaverymanuscripts.org$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/www.batdetective.org.conf
+++ b/sites/www.batdetective.org.conf
@@ -4,7 +4,7 @@ server {
 
     location /talk-player/ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;
         # Exclude X-Frame-Options header
         add_header 'Access-Control-Allow-Origin' '*';
         add_header 'Access-Control-Allow-Credentials' 'true';

--- a/sites/www.scribesofthecairogeniza.org.conf
+++ b/sites/www.scribesofthecairogeniza.org.conf
@@ -4,7 +4,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.scribesofthecairogeniza.org$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.scribesofthecairogeniza.org$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -77,7 +77,7 @@ server {
 
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$uri?$query_string;
+        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;
         include /etc/nginx/proxy-headers.conf;
     }
 

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -90,7 +90,7 @@ server {
             set $proxy_host_header "zooniverse-static.s3-website-us-east-1.amazonaws.com";
         }
         if ($request_method = POST) {
-            proxy_pass             https://panoptes.zooniverse.org$uri;
+            proxy_pass             https://panoptes.zooniverse.org$request_uri;
             set $proxy_host_header "panoptes.zooniverse.org";
         }
         add_header 'Access-Control-Allow-Origin' '*';


### PR DESCRIPTION
Fixes #144 - avoid decoding issue for the upstream proxy - pass the URL path as is to the upstream. 

Sec update: do not allow header injection via $uri and proxy_pass https://stackoverflow.com/questions/48708361/nginx-request-uri-vs-uri/48709976

I've also added notes on how to test the local changes via curl and docker-compose. 