### PR TITLE
Add proxy for www.oldweather.org

### DIFF
--- a/sites/www.oldweather.org.conf
+++ b/sites/www.oldweather.org.conf
@@ -1,0 +1,12 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name www.oldweather.org;
+
+    location / {
+        resolver 8.8.8.8;
+
+        # This is a hack to get nginx to discard the uri in the proxy request
+        proxy_pass             http://oldweather.org.s3-website-us-west-2.amazonaws.com;
+        proxy_set_header       Host oldweather.org.s3-website-us-west-2.amazonaws.com;
+    }
+}


### PR DESCRIPTION
This is hosted in a bucket owned by the project team.

CloudFront does this proxying at the moment.