### PR TITLE
Update penguinwatch.org config

### DIFF
--- a/kubernetes/ingress/penguinwatch.org.yaml
+++ b/kubernetes/ingress/penguinwatch.org.yaml
@@ -1,0 +1,44 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: penguinwatch-org-tls
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer 
+  secretName: penguinwatch-org-tls
+  dnsNames:  
+    - www.penguinwatch.org
+    - talk.penguinwatch.org
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: penguinwatch.org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - www.penguinwatch.org
+    - talk.penguinwatch.org
+    secretName: penguinwatch-org-tls
+  rules:
+  - host: www.penguinwatch.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: talk.penguinwatch.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)

--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -84,12 +84,6 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name blog.penguinwatch.org;
-    return 301 http://penguinlifelines.wordpress.com/;
-}
-
-server {
-    include /etc/nginx/ssl.default.conf;
     server_name press.planethunters.org;
     return 301 http://www.planethunters.org$request_uri;
 }


### PR DESCRIPTION
We own penguinwatch.org but the DNS is managed in NameCheap instead of Route 53, because this domain uses NameCheap's email forwarding feature. The only subdomains which are actually pointing to our infrastructure are `www` and `talk`. The apex domain and `blog` are both redirected in NameCheap.

Note that `www` is a redirect to the Panoptes project, but it's served by K8 since the `/subjects/` route is used by Talk.