### PR TITLE
Add cert for www.citizensciencetoday.org

### DIFF
--- a/kubernetes/ingress/citizensciencetoday.org.yaml
+++ b/kubernetes/ingress/citizensciencetoday.org.yaml
@@ -1,0 +1,35 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: citizensciencetoday-org-tls
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: citizensciencetoday-org-tls
+  dnsNames:
+    - www.citizensciencetoday.org
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: citizensciencetoday.org
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - www.citizensciencetoday.org
+    secretName: citizensciencetoday-org-tls
+  rules:
+  - host: www.citizensciencetoday.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)


### PR DESCRIPTION
This is another one where the DNS and redirects are set up in NameCheap, so we only need a cert for the www subdomain.