### PR TITLE
Fix talk proxy trailing dots

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -34,6 +34,8 @@ http {
                       '"$http_user_agent" $upstream_cache_status' ;
     access_log /dev/stdout main;
     error_log /dev/stderr;
+    # use debug level to debug proxy pass, rewrites and other nginx internals
+    # error_log /dev/stderr debug;
 
     ##
     # Gzip Settings

--- a/sites/invalid-paths.ouroboros.talk.conf
+++ b/sites/invalid-paths.ouroboros.talk.conf
@@ -20,9 +20,20 @@ server {
   # '.' chars are illegal in azure so we mapped it to a
   # '_' char path prefix in azure blob store
   # we will proxy pass to the azure blob mapped '_' file prefix
-  location ~* ^(/users/.+)\.(\/.*)?$ {
+  location ~* ^/users/.+?\.+\/.*?$ {
+
+    # rewrite the 3 possible levels of trailing '.' chars, i checked the data and 3 was the max
+    # stop after each rewrite and try the proxy pass
+    # note the URI contains the host and rewritten path this is sent to proxy_pass via nginx
+    # .../
+    rewrite '^(.+?)\.{3}(\/.*)?$' /$host$1___$2 break;
+    # ../
+    rewrite '^(.+?)\.{2}(\/.*)?$' /$host$1__$2 break;
+    # ./
+    rewrite ^(.+?)\.(\/.*)?$      /$host$1_$2 break;
+
     resolver 8.8.8.8;
-    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$1_$2;
+    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com;
 
     include /etc/nginx/proxy-headers.conf;
   }


### PR DESCRIPTION
some URLs have trailing sequence of '.' chars - the current config didn't rewrite these correctly.

I tested the data we rewrote and we have only `...`, `..` and `.` levels of trailing dots. 
``` bash
$ grep Processing convert_valid_file_paths_for_azure.log | awk '{print $5}' | pcregrep -o1 -i '^.+?(\.+)\/$' | so
rt -r | uniq 
...
..
.
```
This PR adds specific rewrites for each level and proxy_passes the rewritten URI. 

Here are 3 levels of URLs to test this config change
``` bash
curl -v -H "Host: talk.galaxyzoo.org"  localhost:8080/users/MARYAM_goli.../comments.html
curl -v -H "Host: talk.planethunters.org"  localhost:8080/users/Kaltrina../
curl -v -H "Host: radiotalk.galaxyzoo.org"  localhost:8080/users/sergio_vieira_da_silva_j./
```
And when this is deployed all these should work
https://talk.galaxyzoo.org/users/MARYAM_goli.../comments.html
https://talk.planethunters.org/users/Kaltrina../
https://radiotalk.galaxyzoo.org/sergio_vieira_da_silva_j./