### PR TITLE
add non-capture group to handle missing trailing slashes

### DIFF
--- a/sites/invalid-paths.ouroboros.talk.conf
+++ b/sites/invalid-paths.ouroboros.talk.conf
@@ -20,7 +20,7 @@ server {
   # '.' chars are illegal in azure so we mapped it to a
   # '_' char path prefix in azure blob store
   # we will proxy pass to the azure blob mapped '_' file prefix
-  location ~* ^/users/.+?\.+\/.*?$ {
+  location ~* ^/users/.+?\.+(?:\/.*)?$ {
 
     # rewrite the 3 possible levels of trailing '.' chars, i checked the data and 3 was the max
     # stop after each rewrite and try the proxy pass


### PR DESCRIPTION
ensure we rewrite invalid char urls that don't have a trailing slash. This adds a non-capture group that handles optional trailing slashes after invalid char suffixes
This doesn't work
https://talk.galaxyzoo.org/users/MARYAM_goli...
this does
https://talk.galaxyzoo.org/users/MARYAM_goli.../

after the PR both will work.