### PR TITLE
Add redirect for higgshunter blog

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -473,6 +473,12 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
+    server_name blog.higgshunters.org;
+    return 301 https://higgshunters.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
     server_name planetaryresponsenetwork.org planetaryresponsenetwork.net planetaryresponsenetwork.com www.planetaryresponsenetwork.org www.planetaryresponsenetwork.net www.planetaryresponsenetwork.com;
     return 301 https://www.zooniverse.org/projects/mrniaboc/planetary-response-network-hurricane-dorian;
 }


### PR DESCRIPTION
Continuing effort started in #90 and #102, I add another blog redirect in order to discontinue custom domain mapping for Higgs Hunters' WordPress blog.