### PR TITLE
Add redirects for blog retirement, Part 4

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -365,12 +365,12 @@ server {
     rewrite ^/seti/files/(.*) http://zooniverse-resources.s3.amazonaws.com/blogs.zooniverse.org/15/files/$1 last;
     rewrite ^/ancientlives/files/(.*) http://zooniverse-resources.s3.amazonaws.com/blogs.zooniverse.org/13/files/$1 last;
     rewrite ^/files/(.*) http://zooniverse-resources.s3.amazonaws.com/blogs.zooniverse.org/1/files/$1 last;
-    rewrite ^/mwp/(.*)$ http://blog.milkywayproject.org/$1 permanent;
-    rewrite ^/mwp$ http://blog.milkywayproject.org/ permanent;
+    rewrite ^/mwp/(.*)$ https://milkywayproj.wordpress.com/$1 permanent;
+    rewrite ^/mwp$ https://milkywayproj.wordpress.com/ permanent;
     rewrite ^/galaxyzoo/(.*)$ http://blog.galaxyzoo.org/$1 permanent;
     rewrite ^/galaxyzoo$ http://blog.galaxyzoo.org/ permanent;
-    rewrite ^/oldweather/(.*)$ http://blog.oldweather.org/$1 permanent;
-    rewrite ^/oldweather$ http://blog.oldweather.org/ permanent;
+    rewrite ^/oldweather/(.*)$ https://oldweather.wordpress.com/$1 permanent;
+    rewrite ^/oldweather$ https://oldweather.wordpress.com/ permanent;
     rewrite ^/planethunters/(.*)$ http://blog.planethunters.org/$1 permanent;
     rewrite ^/planethunters$ http://blog.planethunters.org/ permanent;
     rewrite ^/whalefm/(.*)$ https://whalefm.wordpress.com/$1 permanent;

--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -479,6 +479,30 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
+    server_name blog.operationwardiary.org;
+    return 301 https://operationwardiary.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name blog.cyclonecenter.org;
+    return 301 https://cyclonecentre.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name blog.oldweather.org;
+    return 301 https://oldweather.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name blog.milkywayproject.org;
+    return 301 https://milkywayproj.wordpress.com$request_uri;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
     server_name planetaryresponsenetwork.org planetaryresponsenetwork.net planetaryresponsenetwork.com www.planetaryresponsenetwork.org www.planetaryresponsenetwork.net www.planetaryresponsenetwork.com;
     return 301 https://www.zooniverse.org/projects/mrniaboc/planetary-response-network-hurricane-dorian;
 }


### PR DESCRIPTION
Continuing efforts to retire old blogs and discontinue paying for WordPress custom domain mapping (see also: #90, #102, #182), I add four more blog redirects for Operation War Diary, Cyclone Center, Old Weather, and Milky Way Project.  These projects constitute the last of the current batch where projects are retired / inactive and most recent post is approx >2 yrs old.

Please note that a second action needs to be taken to complete work: update DNS entries for these projects, as well as for the last few batches.  See PR on Operations repo.

cc: @camallen @zwolf 