### PR TITLE
add server block for data.zooniverse.org

### DIFF
--- a/sites/data.zooniverse.org.conf
+++ b/sites/data.zooniverse.org.conf
@@ -1,0 +1,8 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name data.zooniverse.org;
+
+    location / {
+        return 301 https://s3.amazonaws.com/$host$request_uri;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/zooniverse/help/issues/8 

redirect to the s3 object store URL for the requested resource, e.g. https://s3.amazonaws.com/data.zooniverse.org/tutorial/kitteh_zoo.zip