### PR TITLE
increase cpu request

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -19,7 +19,7 @@ spec:
           resources:
               requests:
                 memory: "50Mi"
-                cpu: "10m"
+                cpu: "250m"
               limits:
                 memory: "50Mi"
                 cpu: "500m"


### PR DESCRIPTION
increase the cpu request value, used as the denominator int he HPA scaling metric target, e.g. 
old behaviour `79Mi use / 10Mi target = 790%` (so max replicas activated)
VS
new behaviour `79Mi use / 250Mi target = 31.6%`