### PR TITLE
increase memory request and limit

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -18,10 +18,10 @@ spec:
           image: zooniverse/http-frontend:__IMAGE_TAG__
           resources:
               requests:
-                memory: "50Mi"
+                memory: "250Mi"
                 cpu: "250m"
               limits:
-                memory: "50Mi"
+                memory: "250Mi"
                 cpu: "500m"
           livenessProbe:
              httpGet:


### PR DESCRIPTION
avoid these pods getting OOMKilled
```
Containers:
  http-frontend-app:
    Image:          zooniverse/http-frontend:f650a2fe305251c6238ab530707eb0b07c70fbdb
    Port:           80/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Wed, 23 Sep 2020 09:18:12 +0100
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Wed, 23 Sep 2020 09:17:42 +0100
      Finished:     Wed, 23 Sep 2020 09:17:46 +0100
    Ready:          True
    Restart Count:  11
    Limits:
      cpu:     500m
      memory:  50Mi
    Requests:
      cpu:      250m
      memory:   50Mi
    Liveness:   http-get http://:80/ delay=0s timeout=1s period=10s #success=1 #failure=3
    Readiness:  http-get http://:80/ delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:
      LOG_STDOUT:  true
```