### PR TITLE
serve www.galaxyzoo.org subjects out of azure

### DIFF
--- a/sites/www.galaxyzoo.org.conf
+++ b/sites/www.galaxyzoo.org.conf
@@ -7,7 +7,8 @@ server {
     include /etc/nginx/api-proxy.conf;
 
     location /subjects/ {
-        return 301 https://s3.amazonaws.com/$host$request_uri;
+        # ensure the $web container path is URL encoded to %24web
+        return 301 https://galaxyzoosubjects.blob.core.windows.net/%24web$request_uri;
     }
 
     location /authors {


### PR DESCRIPTION
switch from s3 to azure blob stores land for serving the subject imagery for www.galaxyzoo.org domain