### PR TITLE
Certmanager update ingresses

### DIFF
--- a/kubernetes/ingress/ancientlives.org.yaml
+++ b/kubernetes/ingress/ancientlives.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ancientlives-org-tls

--- a/kubernetes/ingress/ancientlives.org.yaml
+++ b/kubernetes/ingress/ancientlives.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: ancientlives-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: ancientlives-org-tls
-  dnsNames:  
+  dnsNames:
     - ancientlives.org
     - "*.ancientlives.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: ancientlives.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/andromedaproject.org.yaml
+++ b/kubernetes/ingress/andromedaproject.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: andromedaproject-org-tls

--- a/kubernetes/ingress/andromedaproject.org.yaml
+++ b/kubernetes/ingress/andromedaproject.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: andromedaproject-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: andromedaproject-org-tls
-  dnsNames:  
+  dnsNames:
     - andromedaproject.org
     - "*.andromedaproject.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: andromedaproject.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/antislaverymanuscripts.org.yaml
+++ b/kubernetes/ingress/antislaverymanuscripts.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: antislaverymanuscripts-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: antislaverymanuscripts-org-tls
-  dnsNames:  
+  dnsNames:
     - antislaverymanuscripts.org
     - "*.antislaverymanuscripts.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: antislaverymanuscripts.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/antislaverymanuscripts.org.yaml
+++ b/kubernetes/ingress/antislaverymanuscripts.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: antislaverymanuscripts-org-tls

--- a/kubernetes/ingress/arizonabatwatch.org.yaml
+++ b/kubernetes/ingress/arizonabatwatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: arizonabatwatch-org-tls

--- a/kubernetes/ingress/arizonabatwatch.org.yaml
+++ b/kubernetes/ingress/arizonabatwatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: arizonabatwatch-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: arizonabatwatch.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/asteroidzoo.org.uk.yaml
+++ b/kubernetes/ingress/asteroidzoo.org.uk.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: asteroidzoo-org-uk-tls

--- a/kubernetes/ingress/asteroidzoo.org.uk.yaml
+++ b/kubernetes/ingress/asteroidzoo.org.uk.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: asteroidzoo-org-uk-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: asteroidzoo-org-uk-tls
-  dnsNames:  
+  dnsNames:
     - asteroidzoo.org.uk
     - "*.asteroidzoo.org.uk"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: asteroidzoo.org.uk
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/asteroidzoo.org.yaml
+++ b/kubernetes/ingress/asteroidzoo.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: asteroidzoo-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: asteroidzoo-org-tls
-  dnsNames:  
+  dnsNames:
     - asteroidzoo.org
     - "*.asteroidzoo.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: asteroidzoo.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/asteroidzoo.org.yaml
+++ b/kubernetes/ingress/asteroidzoo.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: asteroidzoo-org-tls

--- a/kubernetes/ingress/astronomyrewind.org.yaml
+++ b/kubernetes/ingress/astronomyrewind.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: astronomyrewind-org-tls

--- a/kubernetes/ingress/astronomyrewind.org.yaml
+++ b/kubernetes/ingress/astronomyrewind.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: astronomyrewind-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: astronomyrewind.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/backyardworlds_org.yaml
+++ b/kubernetes/ingress/backyardworlds_org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: backyardworlds-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: backyardworlds.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/backyardworlds_org.yaml
+++ b/kubernetes/ingress/backyardworlds_org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: backyardworlds-org-tls

--- a/kubernetes/ingress/batdetective.org.yaml
+++ b/kubernetes/ingress/batdetective.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: batdetective-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: batdetective-org-tls
-  dnsNames:  
+  dnsNames:
     - batdetective.org
     - "*.batdetective.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: batdetective.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/batdetective.org.yaml
+++ b/kubernetes/ingress/batdetective.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: batdetective-org-tls

--- a/kubernetes/ingress/cellslider.net.yaml
+++ b/kubernetes/ingress/cellslider.net.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: cellslider-net-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: cellslider-net-tls
-  dnsNames:  
+  dnsNames:
     - cellslider.net
     - "*.cellslider.net"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: cellslider.net
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/cellslider.net.yaml
+++ b/kubernetes/ingress/cellslider.net.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cellslider-net-tls

--- a/kubernetes/ingress/chicagowildlifewatch.org.yaml
+++ b/kubernetes/ingress/chicagowildlifewatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: chicagowildlifewatch-org-tls

--- a/kubernetes/ingress/chicagowildlifewatch.org.yaml
+++ b/kubernetes/ingress/chicagowildlifewatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: chicagowildlifewatch-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: chicagowildlifewatch-org-tls
-  dnsNames:  
+  dnsNames:
     - chicagowildlifewatch.org
     - "*.chicagowildlifewatch.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: chicagowildlifewatch.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/chimpandsee.org.yaml
+++ b/kubernetes/ingress/chimpandsee.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: chimpandsee-org-tls

--- a/kubernetes/ingress/chimpandsee.org.yaml
+++ b/kubernetes/ingress/chimpandsee.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: chimpandsee-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: chimpandsee.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/citizensciencealliance.org.yaml
+++ b/kubernetes/ingress/citizensciencealliance.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: citizensciencealliance-org-tls

--- a/kubernetes/ingress/citizensciencealliance.org.yaml
+++ b/kubernetes/ingress/citizensciencealliance.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: citizensciencealliance-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: citizensciencealliance.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/citizensciencetoday.org.yaml
+++ b/kubernetes/ingress/citizensciencetoday.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: citizensciencetoday-org-tls

--- a/kubernetes/ingress/citizensciencetoday.org.yaml
+++ b/kubernetes/ingress/citizensciencetoday.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: citizensciencetoday-org-tls
@@ -16,7 +16,7 @@ metadata:
   name: citizensciencetoday.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/clicktocure.net.yaml
+++ b/kubernetes/ingress/clicktocure.net.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: clicktocure-net-tls

--- a/kubernetes/ingress/clicktocure.net.yaml
+++ b/kubernetes/ingress/clicktocure.net.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: clicktocure-net-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: clicktocure-net-tls
-  dnsNames:  
+  dnsNames:
     - clicktocure.net
     - "*.clicktocure.net"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: clicktocure.net
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/condorwatch.org.yaml
+++ b/kubernetes/ingress/condorwatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: condorwatch-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: condorwatch-org-tls
-  dnsNames:  
+  dnsNames:
     - condorwatch.org
     - "*.condorwatch.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: condorwatch-org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/condorwatch.org.yaml
+++ b/kubernetes/ingress/condorwatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: condorwatch-org-tls

--- a/kubernetes/ingress/conversationsonnature.com.yaml
+++ b/kubernetes/ingress/conversationsonnature.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: conversationsonnature-com-tls
@@ -19,7 +19,7 @@ metadata:
   name: conversationsonnature.com
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/conversationsonnature.com.yaml
+++ b/kubernetes/ingress/conversationsonnature.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: conversationsonnature-com-tls

--- a/kubernetes/ingress/cyclonecenter.org.yaml
+++ b/kubernetes/ingress/cyclonecenter.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cyclonecenter-org-tls

--- a/kubernetes/ingress/cyclonecenter.org.yaml
+++ b/kubernetes/ingress/cyclonecenter.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: cyclonecenter-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: cyclonecenter-org-tls
-  dnsNames:  
+  dnsNames:
     - cyclonecenter.org
     - "*.cyclonecenter.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: cyclonecenter.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/cyclonecentre.org.yaml
+++ b/kubernetes/ingress/cyclonecentre.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cyclonecentre-org-tls

--- a/kubernetes/ingress/cyclonecentre.org.yaml
+++ b/kubernetes/ingress/cyclonecentre.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: cyclonecentre-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: cyclonecentre-org-tls
-  dnsNames:  
+  dnsNames:
     - cyclonecentre.org
     - "*.cyclonecentre.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: cyclonecentre.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/decodingthecivilwar.org.yaml
+++ b/kubernetes/ingress/decodingthecivilwar.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: decodingthecivilwar-org-tls

--- a/kubernetes/ingress/decodingthecivilwar.org.yaml
+++ b/kubernetes/ingress/decodingthecivilwar.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: decodingthecivilwar-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: decodingthecivilwar.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/diagnosislondon.org.yaml
+++ b/kubernetes/ingress/diagnosislondon.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: diagnosislondon-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: diagnosislondon.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/diagnosislondon.org.yaml
+++ b/kubernetes/ingress/diagnosislondon.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: diagnosislondon-org-tls

--- a/kubernetes/ingress/diskdetective.org.yaml
+++ b/kubernetes/ingress/diskdetective.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: diskdetective-org-tls

--- a/kubernetes/ingress/diskdetective.org.yaml
+++ b/kubernetes/ingress/diskdetective.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: diskdetective-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: diskdetective-org-tls
-  dnsNames:  
+  dnsNames:
     - diskdetective.org
     - "*.diskdetective.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: diskdetective.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/exoplanetexplorers.org.yaml
+++ b/kubernetes/ingress/exoplanetexplorers.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: exoplanetexplorers-org-tls

--- a/kubernetes/ingress/exoplanetexplorers.org.yaml
+++ b/kubernetes/ingress/exoplanetexplorers.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: exoplanetexplorers-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: exoplanetexplorers.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/floatingforests.org.yaml
+++ b/kubernetes/ingress/floatingforests.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: floatingforests-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: floatingforests-org-tls
-  dnsNames:  
+  dnsNames:
     - floatingforests.org
     - "*.floatingforests.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: floatingforests.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/floatingforests.org.yaml
+++ b/kubernetes/ingress/floatingforests.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: floatingforests-org-tls

--- a/kubernetes/ingress/galaxyzoo.org.yaml
+++ b/kubernetes/ingress/galaxyzoo.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: www-galaxyzoo-org-tls
@@ -35,7 +35,7 @@ spec:
           servicePort: 80
         path: /
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: galaxyzoo-org-tls

--- a/kubernetes/ingress/galaxyzooblog.org.yaml
+++ b/kubernetes/ingress/galaxyzooblog.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: galaxyzooblog-org-tls

--- a/kubernetes/ingress/galaxyzooblog.org.yaml
+++ b/kubernetes/ingress/galaxyzooblog.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: galaxyzooblog-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: galaxyzooblog-org-tls
-  dnsNames:  
+  dnsNames:
     - galaxyzooblog.org
     - "*.galaxyzooblog.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: galaxyzooblog.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/galaxyzooforum.org.yaml
+++ b/kubernetes/ingress/galaxyzooforum.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: galaxyzooforum-org-tls

--- a/kubernetes/ingress/galaxyzooforum.org.yaml
+++ b/kubernetes/ingress/galaxyzooforum.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: galaxyzooforum-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: galaxyzooforum-org-tls
-  dnsNames:  
+  dnsNames:
     - galaxyzooforum.org
     - "*.galaxyzooforum.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: galaxyzooforum.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/gravityspy.org.yaml
+++ b/kubernetes/ingress/gravityspy.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: gravityspy-org-tls

--- a/kubernetes/ingress/gravityspy.org.yaml
+++ b/kubernetes/ingress/gravityspy.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: gravityspy-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: gravityspy.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/higgshunters.org.yaml
+++ b/kubernetes/ingress/higgshunters.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: higgshunters-org-tls

--- a/kubernetes/ingress/higgshunters.org.yaml
+++ b/kubernetes/ingress/higgshunters.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: higgshunters-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: higgshunters-org-tls
-  dnsNames:  
+  dnsNames:
     - higgshunters.org
     - "*.higgshunters.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: higgshunters.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/mappinghistoricskies.org.yaml
+++ b/kubernetes/ingress/mappinghistoricskies.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: mappinghistoricskies-org-tls

--- a/kubernetes/ingress/mappinghistoricskies.org.yaml
+++ b/kubernetes/ingress/mappinghistoricskies.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: mappinghistoricskies-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: mappinghistoricskies.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/measuringtheanzacs.org.yaml
+++ b/kubernetes/ingress/measuringtheanzacs.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: measuringtheanzacs-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: measuringtheanzacs.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/measuringtheanzacs.org.yaml
+++ b/kubernetes/ingress/measuringtheanzacs.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: measuringtheanzacs-org-tls

--- a/kubernetes/ingress/microplants.org.yaml
+++ b/kubernetes/ingress/microplants.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: microplants-org-tls

--- a/kubernetes/ingress/microplants.org.yaml
+++ b/kubernetes/ingress/microplants.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: microplants-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: microplants-org-tls
-  dnsNames:  
+  dnsNames:
     - microplants.org
     - "*.microplants.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: microplants.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/milkywayproject.org.yaml
+++ b/kubernetes/ingress/milkywayproject.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: milkywayproject-org-tls

--- a/kubernetes/ingress/milkywayproject.org.yaml
+++ b/kubernetes/ingress/milkywayproject.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: milkywayproject-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: milkywayproject-org-tls
-  dnsNames:  
+  dnsNames:
     - milkywayproject.org
     - "*.milkywayproject.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: milkywayproject.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/moonzoo.org.yaml
+++ b/kubernetes/ingress/moonzoo.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: moonzoo-org-tls

--- a/kubernetes/ingress/moonzoo.org.yaml
+++ b/kubernetes/ingress/moonzoo.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: moonzoo-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: moonzoo-org-tls
-  dnsNames:  
+  dnsNames:
     - moonzoo.org
     - "*.moonzoo.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: moonzoo.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/muonhunter.org.yaml
+++ b/kubernetes/ingress/muonhunter.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: muonhunter-org-tls

--- a/kubernetes/ingress/muonhunter.org.yaml
+++ b/kubernetes/ingress/muonhunter.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: muonhunter-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: muonhunter.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/muonhunters.org.yaml
+++ b/kubernetes/ingress/muonhunters.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: muonhunters-org-tls

--- a/kubernetes/ingress/muonhunters.org.yaml
+++ b/kubernetes/ingress/muonhunters.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: muonhunters-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: muonhunters.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/nameexoworlds.org.yaml
+++ b/kubernetes/ingress/nameexoworlds.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: nameexoworlds-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: nameexoworlds-org-tls
-  dnsNames:  
+  dnsNames:
     - nameexoworlds.org
     - "*.nameexoworlds.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: nameexoworlds.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/nameexoworlds.org.yaml
+++ b/kubernetes/ingress/nameexoworlds.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: nameexoworlds-org-tls

--- a/kubernetes/ingress/notesfromnature.org.yaml
+++ b/kubernetes/ingress/notesfromnature.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: notesfromnature-org-tls

--- a/kubernetes/ingress/notesfromnature.org.yaml
+++ b/kubernetes/ingress/notesfromnature.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: notesfromnature-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: notesfromnature-org-tls
-  dnsNames:  
+  dnsNames:
     - notesfromnature.org
     - "*.notesfromnature.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: notesfromnature.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/oldweather.org.yaml
+++ b/kubernetes/ingress/oldweather.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: oldweather-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: oldweather-org-tls
-  dnsNames:  
+  dnsNames:
     - oldweather.org
     - "*.oldweather.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: oldweather.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/oldweather.org.yaml
+++ b/kubernetes/ingress/oldweather.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: oldweather-org-tls

--- a/kubernetes/ingress/operationwardiary.org.yaml
+++ b/kubernetes/ingress/operationwardiary.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: operationwardiary-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: operationwardiary-org-tls
-  dnsNames:  
+  dnsNames:
     - operationwardiary.org
     - "*.operationwardiary.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: operationwardiary-org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/operationwardiary.org.yaml
+++ b/kubernetes/ingress/operationwardiary.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: operationwardiary-org-tls

--- a/kubernetes/ingress/orchidobservers.org.yaml
+++ b/kubernetes/ingress/orchidobservers.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: orchidobservers-org-tls

--- a/kubernetes/ingress/orchidobservers.org.yaml
+++ b/kubernetes/ingress/orchidobservers.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: orchidobservers-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: orchidobservers.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/penguinwatch.org.yaml
+++ b/kubernetes/ingress/penguinwatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: penguinwatch-org-tls

--- a/kubernetes/ingress/penguinwatch.org.yaml
+++ b/kubernetes/ingress/penguinwatch.org.yaml
@@ -1,13 +1,13 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: penguinwatch-org-tls
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: penguinwatch-org-tls
-  dnsNames:  
+  dnsNames:
     - www.penguinwatch.org
     - talk.penguinwatch.org
 ---
@@ -17,7 +17,7 @@ metadata:
   name: penguinwatch.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/planet4.org.yaml
+++ b/kubernetes/ingress/planet4.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: planet4-org-tls

--- a/kubernetes/ingress/planet4.org.yaml
+++ b/kubernetes/ingress/planet4.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: planet4-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: planet4-org-tls
-  dnsNames:  
+  dnsNames:
     - planet4.org
     - "*.planet4.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: planet4.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/planet9search.org.yaml
+++ b/kubernetes/ingress/planet9search.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: planet9search-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: planet9search.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/planet9search.org.yaml
+++ b/kubernetes/ingress/planet9search.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: planet9search-org-tls

--- a/kubernetes/ingress/planetaryresponsenetwork.com.yaml
+++ b/kubernetes/ingress/planetaryresponsenetwork.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: planetaryresponsenetwork-com-tls
@@ -19,7 +19,7 @@ metadata:
   name: planetaryresponsenetwork.com
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/planetaryresponsenetwork.com.yaml
+++ b/kubernetes/ingress/planetaryresponsenetwork.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: planetaryresponsenetwork-com-tls

--- a/kubernetes/ingress/planetaryresponsenetwork.net.yaml
+++ b/kubernetes/ingress/planetaryresponsenetwork.net.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: planetaryresponsenetwork-net-tls
@@ -19,7 +19,7 @@ metadata:
   name: planetaryresponsenetwork.net
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/planetaryresponsenetwork.net.yaml
+++ b/kubernetes/ingress/planetaryresponsenetwork.net.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: planetaryresponsenetwork-net-tls

--- a/kubernetes/ingress/planetaryresponsenetwork.org.yaml
+++ b/kubernetes/ingress/planetaryresponsenetwork.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: planetaryresponsenetwork-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: planetaryresponsenetwork.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/planetaryresponsenetwork.org.yaml
+++ b/kubernetes/ingress/planetaryresponsenetwork.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: planetaryresponsenetwork-org-tls

--- a/kubernetes/ingress/planetfour.org.yaml
+++ b/kubernetes/ingress/planetfour.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: planetfour-org-tls

--- a/kubernetes/ingress/planetfour.org.yaml
+++ b/kubernetes/ingress/planetfour.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: planetfour-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: planetfour-org-tls
-  dnsNames:  
+  dnsNames:
     - planetfour.org
     - "*.planetfour.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: planetfour-org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/planethunters.org.yaml
+++ b/kubernetes/ingress/planethunters.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: planethunters-org-tls

--- a/kubernetes/ingress/planethunters.org.yaml
+++ b/kubernetes/ingress/planethunters.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: planethunters-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: planethunters-org-tls
-  dnsNames:  
+  dnsNames:
     - planethunters.org
     - "*.planethunters.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: planethunters.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/planetninesearch.org.yaml
+++ b/kubernetes/ingress/planetninesearch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: planetninesearch-org-tls

--- a/kubernetes/ingress/planetninesearch.org.yaml
+++ b/kubernetes/ingress/planetninesearch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: planetninesearch-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: planetninesearch.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/planktonportal.org.yaml
+++ b/kubernetes/ingress/planktonportal.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: planktonportal-org-tls

--- a/kubernetes/ingress/planktonportal.org.yaml
+++ b/kubernetes/ingress/planktonportal.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: planktonportal-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: planktonportal-org-tls
-  dnsNames:  
+  dnsNames:
     - planktonportal.org
     - "*.planktonportal.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: planktonportal-org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/pulsarhunter.com.yaml
+++ b/kubernetes/ingress/pulsarhunter.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: pulsarhunter-com-tls

--- a/kubernetes/ingress/pulsarhunter.com.yaml
+++ b/kubernetes/ingress/pulsarhunter.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: pulsarhunter-com-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: pulsarhunter-com-tls
-  dnsNames:  
+  dnsNames:
     - pulsarhunter.com
     - "*.pulsarhunter.com"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: pulsarhunter.com
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/pulsarhunter.org.yaml
+++ b/kubernetes/ingress/pulsarhunter.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: pulsarhunter-org-tls

--- a/kubernetes/ingress/pulsarhunter.org.yaml
+++ b/kubernetes/ingress/pulsarhunter.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: pulsarhunter-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: pulsarhunter-org-tls
-  dnsNames:  
+  dnsNames:
     - pulsarhunter.org
     - "*.pulsarhunter.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: pulsarhunter.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/pulsarhunters.com.yaml
+++ b/kubernetes/ingress/pulsarhunters.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: pulsarhunters-com-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: pulsarhunters-com-tls
-  dnsNames:  
+  dnsNames:
     - pulsarhunters.com
     - "*.pulsarhunters.com"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: pulsarhunters.com
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/pulsarhunters.com.yaml
+++ b/kubernetes/ingress/pulsarhunters.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: pulsarhunters-com-tls

--- a/kubernetes/ingress/pulsarhunters.org.yaml
+++ b/kubernetes/ingress/pulsarhunters.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: pulsarhunters-org-tls

--- a/kubernetes/ingress/pulsarhunters.org.yaml
+++ b/kubernetes/ingress/pulsarhunters.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: pulsarhunters-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: pulsarhunters-org-tls
-  dnsNames:  
+  dnsNames:
     - pulsarhunters.org
     - "*.pulsarhunters.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: pulsarhunters.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/rogueworlds.org.yaml
+++ b/kubernetes/ingress/rogueworlds.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: rogueworlds-org-tls
@@ -19,7 +19,7 @@ metadata:
   name: rogueworlds.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/rogueworlds.org.yaml
+++ b/kubernetes/ingress/rogueworlds.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: rogueworlds-org-tls

--- a/kubernetes/ingress/sciencegossip.org.yaml
+++ b/kubernetes/ingress/sciencegossip.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: sciencegossip-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: sciencegossip-org-tls
-  dnsNames:  
+  dnsNames:
     - sciencegossip.org
     - "*.sciencegossip.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: sciencegossip.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/sciencegossip.org.yaml
+++ b/kubernetes/ingress/sciencegossip.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: sciencegossip-org-tls

--- a/kubernetes/ingress/scribesofthecairogeniza.org.yaml
+++ b/kubernetes/ingress/scribesofthecairogeniza.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: scribesofthecairogeniza-org-tls

--- a/kubernetes/ingress/scribesofthecairogeniza.org.yaml
+++ b/kubernetes/ingress/scribesofthecairogeniza.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: scribesofthecairogeniza-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: scribesofthecairogeniza-org-tls
-  dnsNames:  
+  dnsNames:
     - scribesofthecairogeniza.org
     - "*.scribesofthecairogeniza.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: scribesofthecairogeniza.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/seabirdwatch.org.yaml
+++ b/kubernetes/ingress/seabirdwatch.org.yaml
@@ -1,13 +1,13 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: seabirdwatch-org-tls
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: seabirdwatch-org-tls
-  dnsNames:  
+  dnsNames:
     - seabirdwatch.org
     - www.seabirdwatch.org
 ---
@@ -17,7 +17,7 @@ metadata:
   name: seabirdwatch.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/seabirdwatch.org.yaml
+++ b/kubernetes/ingress/seabirdwatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: seabirdwatch-org-tls

--- a/kubernetes/ingress/seafloorexplorer.org.yaml
+++ b/kubernetes/ingress/seafloorexplorer.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: seafloorexplorer-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: seafloorexplorer-org-tls
-  dnsNames:  
+  dnsNames:
     - seafloorexplorer.org
     - "*.seafloorexplorer.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: seafloorexplorer.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/seafloorexplorer.org.yaml
+++ b/kubernetes/ingress/seafloorexplorer.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: seafloorexplorer-org-tls

--- a/kubernetes/ingress/setilive.org.yaml
+++ b/kubernetes/ingress/setilive.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: setilive-org-tls

--- a/kubernetes/ingress/setilive.org.yaml
+++ b/kubernetes/ingress/setilive.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: setilive-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: setilive-org-tls
-  dnsNames:  
+  dnsNames:
     - setilive.org
     - "*.setilive.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: setilive-org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/shakespearesworld.org.yaml
+++ b/kubernetes/ingress/shakespearesworld.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: shakespearesworld-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: shakespearesworld-org-tls
-  dnsNames:  
+  dnsNames:
     - shakespearesworld.org
     - "*.shakespearesworld.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: shakespearesworld.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/shakespearesworld.org.yaml
+++ b/kubernetes/ingress/shakespearesworld.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: shakespearesworld-org-tls

--- a/kubernetes/ingress/snapshotserengeti.org.yaml
+++ b/kubernetes/ingress/snapshotserengeti.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: snapshotserengeti-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: snapshotserengeti-org-tls
-  dnsNames:  
+  dnsNames:
     - snapshotserengeti.org
     - "*.snapshotserengeti.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: snapshotserengeti.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/snapshotserengeti.org.yaml
+++ b/kubernetes/ingress/snapshotserengeti.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: snapshotserengeti-org-tls

--- a/kubernetes/ingress/snapshotsupernova.org.yaml
+++ b/kubernetes/ingress/snapshotsupernova.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: snapshotsupernova-org-tls

--- a/kubernetes/ingress/snapshotsupernova.org.yaml
+++ b/kubernetes/ingress/snapshotsupernova.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: snapshotsupernova-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: snapshotsupernova-org-tls
-  dnsNames:  
+  dnsNames:
     - snapshotsupernova.org
     - "*.snapshotsupernova.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: snapshotsupernova.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/snapshotsupernovae.org.yaml
+++ b/kubernetes/ingress/snapshotsupernovae.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: snapshotsupernovae-org-tls

--- a/kubernetes/ingress/snapshotsupernovae.org.yaml
+++ b/kubernetes/ingress/snapshotsupernovae.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: snapshotsupernovae-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: snapshotsupernovae-org-tls
-  dnsNames:  
+  dnsNames:
     - snapshotsupernovae.org
     - "*.snapshotsupernovae.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: snapshotsupernovae.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/solarstormwatch.com.yaml
+++ b/kubernetes/ingress/solarstormwatch.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: solarstormwatch-com-tls

--- a/kubernetes/ingress/solarstormwatch.com.yaml
+++ b/kubernetes/ingress/solarstormwatch.com.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: solarstormwatch-com-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: solarstormwatch-com-tls
-  dnsNames:  
+  dnsNames:
     - solarstormwatch.com
     - "*.solarstormwatch.com"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: solarstormwatch.com
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/spacewarps.org.yaml
+++ b/kubernetes/ingress/spacewarps.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: spacewarps-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: spacewarps-org-tls
-  dnsNames:  
+  dnsNames:
     - spacewarps.org
     - "*.spacewarps.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: spacewarps-org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/spacewarps.org.yaml
+++ b/kubernetes/ingress/spacewarps.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: spacewarps-org-tls

--- a/kubernetes/ingress/sunspotter.org.yaml
+++ b/kubernetes/ingress/sunspotter.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: sunspotter-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: sunspotter-org-tls
-  dnsNames:  
+  dnsNames:
     - sunspotter.org
     - "*.sunspotter.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: sunspotter.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/sunspotter.org.yaml
+++ b/kubernetes/ingress/sunspotter.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: sunspotter-org-tls

--- a/kubernetes/ingress/supernovasighting.org.yaml
+++ b/kubernetes/ingress/supernovasighting.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: supernovasighting-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: supernovasighting-org-tls
-  dnsNames:  
+  dnsNames:
     - supernovasighting.org
     - "*.supernovasighting.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: supernovasighting.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/supernovasighting.org.yaml
+++ b/kubernetes/ingress/supernovasighting.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: supernovasighting-org-tls

--- a/kubernetes/ingress/theandromedaproject.org.yaml
+++ b/kubernetes/ingress/theandromedaproject.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: theandromedaproject-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: theandromedaproject-org-tls
-  dnsNames:  
+  dnsNames:
     - theandromedaproject.org
     - "*.theandromedaproject.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: theandromedaproject.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/theandromedaproject.org.yaml
+++ b/kubernetes/ingress/theandromedaproject.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: theandromedaproject-org-tls

--- a/kubernetes/ingress/thetriangulumproject.org.yaml
+++ b/kubernetes/ingress/thetriangulumproject.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: thetriangulumproject-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: thetriangulumproject-org-tls
-  dnsNames:  
+  dnsNames:
     - thetriangulumproject.org
     - "*.thetriangulumproject.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: thetriangulumproject.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/thetriangulumproject.org.yaml
+++ b/kubernetes/ingress/thetriangulumproject.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: thetriangulumproject-org-tls

--- a/kubernetes/ingress/thezooniverse.org.yaml
+++ b/kubernetes/ingress/thezooniverse.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: thezooniverse-org-tls

--- a/kubernetes/ingress/thezooniverse.org.yaml
+++ b/kubernetes/ingress/thezooniverse.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: thezooniverse-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: thezooniverse-org-tls
-  dnsNames:  
+  dnsNames:
     - thezooniverse.org
     - "*.thezooniverse.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: thezooniverse.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/usawildlifewatch.org.yaml
+++ b/kubernetes/ingress/usawildlifewatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: usawildlifewatch-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: usawildlifewatch-org-tls
-  dnsNames:  
+  dnsNames:
     - usawildlifewatch.org
     - "*.usawildlifewatch.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: usawildlifewatch.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/usawildlifewatch.org.yaml
+++ b/kubernetes/ingress/usawildlifewatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: usawildlifewatch-org-tls

--- a/kubernetes/ingress/wildcamdarien.org.yaml
+++ b/kubernetes/ingress/wildcamdarien.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: wildcamdarien-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: wildcamdarien-org-tls
-  dnsNames:  
+  dnsNames:
     - wildcamdarien.org
     - "*.wildcamdarien.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: wildcamdarien.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/wildcamdarien.org.yaml
+++ b/kubernetes/ingress/wildcamdarien.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: wildcamdarien-org-tls

--- a/kubernetes/ingress/wildcamgorongosa.org.yaml
+++ b/kubernetes/ingress/wildcamgorongosa.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: wildcamgorongosa-org-tls

--- a/kubernetes/ingress/wildcamgorongosa.org.yaml
+++ b/kubernetes/ingress/wildcamgorongosa.org.yaml
@@ -1,13 +1,13 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: wildcamgorongosa-org-tls
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: wildcamgorongosa-org-tls
-  dnsNames:  
+  dnsNames:
     - wildcamgorongosa.org
     - www.wildcamgorongosa.org
     - lab.wildcamgorongosa.org
@@ -19,7 +19,7 @@ metadata:
   name: wildcamgorongosa.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/wisconsinwildlifewatch.org.yaml
+++ b/kubernetes/ingress/wisconsinwildlifewatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: wisconsinwildlifewatch-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: wisconsinwildlifewatch-org-tls
-  dnsNames:  
+  dnsNames:
     - wisconsinwildlifewatch.org
     - "*.wisconsinwildlifewatch.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: wisconsinwildlifewatch.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/wisconsinwildlifewatch.org.yaml
+++ b/kubernetes/ingress/wisconsinwildlifewatch.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: wisconsinwildlifewatch-org-tls

--- a/kubernetes/ingress/wormwatchlab.org.yaml
+++ b/kubernetes/ingress/wormwatchlab.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: wormwatchlab-org-tls

--- a/kubernetes/ingress/wormwatchlab.org.yaml
+++ b/kubernetes/ingress/wormwatchlab.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: wormwatchlab-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: wormwatchlab-org-tls
-  dnsNames:  
+  dnsNames:
     - wormwatchlab.org
     - "*.wormwatchlab.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: wormwatchlab-org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/zooinverse.org.yaml
+++ b/kubernetes/ingress/zooinverse.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: zooinverse-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: zooinverse-org-tls
-  dnsNames:  
+  dnsNames:
     - zooinverse.org
     - "*.zooinverse.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: zooinverse-org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/zooinverse.org.yaml
+++ b/kubernetes/ingress/zooinverse.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: zooinverse-org-tls

--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: zooniverse-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: zooniverse-org-tls
-  dnsNames:  
+  dnsNames:
     - zooniverse.org
     - "*.zooniverse.org"
     - "*.staging.zooniverse.org"
@@ -23,7 +23,7 @@ metadata:
   name: zooniverse-org-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: zooniverse-org-tls

--- a/kubernetes/ingress/zooteach.org.yaml
+++ b/kubernetes/ingress/zooteach.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: zooteach-org-tls

--- a/kubernetes/ingress/zooteach.org.yaml
+++ b/kubernetes/ingress/zooteach.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: zooteach-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: zooteach-org-tls
-  dnsNames:  
+  dnsNames:
     - zooteach.org
     - "*.zooteach.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: zooteach.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/zwickytransients.org.yaml
+++ b/kubernetes/ingress/zwickytransients.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha1
 kind: Certificate
 metadata:
   name: zwickytransients-org-tls
@@ -7,9 +7,9 @@ metadata:
 spec:
   issuerRef:
     name: letsencrypt-prod
-    kind: ClusterIssuer 
+    kind: ClusterIssuer
   secretName: zwickytransients-org-tls
-  dnsNames:  
+  dnsNames:
     - zwickytransients.org
     - "*.zwickytransients.org"
 ---
@@ -19,7 +19,7 @@ metadata:
   name: zwickytransients.org
   annotations:
     kubernetes.io/ingress.class: nginx
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"

--- a/kubernetes/ingress/zwickytransients.org.yaml
+++ b/kubernetes/ingress/zwickytransients.org.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: zwickytransients-org-tls


### PR DESCRIPTION
This PR updates the annotations on the the 81 web ingress files in the static repo. Instead of the point by point version upgrade, we're reinstalling and the old annotations need to match what the new version expects.

Merging this PR will update the certs and ingresses in place, but won't recreate them. However, uninstalling cert-manager via Helm and deleting/recreating all the required CRDs likely will, so this should be merged when a) we have a working, up to date cert-manager in the cluster and b) the new annotations have been tested by locally/manually applying a single ingress and making sure it issues the cert correctly. 

This requirement is found here: https://cert-manager.io/docs/installation/upgrading/upgrading-0.10-0.11/

DO NOT MERGE UNTIL CERT-MANAGER UPDATE IS COMPLETE.