### PR TITLE
remove mturk domain from CSP

### DIFF
--- a/sites/star.pfe-preview.zooniverse.org.conf
+++ b/sites/star.pfe-preview.zooniverse.org.conf
@@ -1,5 +1,5 @@
 server {
-    set $csp_whitelist "zooniverse.org *.zooniverse.org *.mturk.com";
+    set $csp_whitelist "zooniverse.org *.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
     server_name "~^(?P<subdomain>.*)\.pfe-preview\.zooniverse\.org$";
 


### PR DESCRIPTION
we don't need this anymore as this was used to test out the https://github.com/zooniverse/mechanical_zoo system