### PR TITLE
Serve seafloorexplorer.org from Azure

### DIFF
--- a/sites/www.seafloorexplorer.org.conf
+++ b/sites/www.seafloorexplorer.org.conf
@@ -9,7 +9,10 @@ server {
     location / {
         resolver 8.8.8.8;
         proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
-        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/www.seafloorexplorer.org/;
+
+        # Serve root index page regardless of what the URI says
+        set $uri_path "www.seafloorexplorer.org/";
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$uri_path;
 
         proxy_http_version 1.1;
     }

--- a/sites/www.seafloorexplorer.org.conf
+++ b/sites/www.seafloorexplorer.org.conf
@@ -9,11 +9,21 @@ server {
     location / {
         resolver 8.8.8.8;
         proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
+        proxy_http_version 1.1;
+
+        add_header 'X-Content-Type-Options' 'nosniff';
+        add_header 'Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+        add_header 'X-Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+        add_header 'X-XSS-Protection' '1; mode=block';
+
+        proxy_cache            STATIC;
+        proxy_cache_valid      200  1d;
+        proxy_cache_use_stale  error timeout invalid_header updating
+                    http_500 http_502 http_503 http_504;
 
         # Serve root index page regardless of what the URI says
         set $uri_path "www.seafloorexplorer.org/";
         proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$uri_path;
 
-        proxy_http_version 1.1;
     }
 }

--- a/sites/www.seafloorexplorer.org.conf
+++ b/sites/www.seafloorexplorer.org.conf
@@ -4,34 +4,9 @@ server {
 
     location / {
         resolver 8.8.8.8;
-
-        # Include all proxy headers so that the Host can be changed
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Credentials' 'true';
-        add_header 'Access-Control-Allow-Methods' 'GET';
-        add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-        add_header 'X-Content-Type-Options' 'nosniff';
-        add_header 'Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
-        add_header 'X-Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
-        add_header 'X-XSS-Protection' '1; mode=block';
-
         proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/www.seafloorexplorer.org/;
 
-        proxy_redirect         /$host/ /;
-        proxy_cache            STATIC;
-        proxy_cache_valid      200  1d;
-        proxy_cache_use_stale  error timeout invalid_header updating
-                    http_500 http_502 http_503 http_504;
-        proxy_hide_header Access-Control-Allow-Origin;
-        proxy_hide_header Access-Control-Allow-Credentials;
-        proxy_hide_header Access-Control-Allow-Methods;
-        proxy_hide_header Access-Control-Allow-Headers;
-
-        # Contents of proxy.conf, updated to AZ
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.seafloorexplorer.org$request_uri;
-
-        # This is a hack to get nginx to discard the uri in the proxy request
-        set $uri_path "www.seafloorexplorer.org/";
-        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$uri_path;
+        proxy_http_version 1.1;
     }
 }

--- a/sites/www.seafloorexplorer.org.conf
+++ b/sites/www.seafloorexplorer.org.conf
@@ -1,12 +1,37 @@
-# Projects where most of the subject URLs are hard-coded to S3.
-# We need to redirect the few that use the project domain instead.
 server {
     include /etc/nginx/ssl.default.conf;
     server_name www.seafloorexplorer.org;
 
-    location /subjects/ {
-        return 301 https://s3.amazonaws.com/$host$request_uri;
-    }
+    location / {
+        resolver 8.8.8.8;
 
-    include /etc/nginx/proxy.conf;
+        # Include all proxy headers so that the Host can be changed
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        add_header 'Access-Control-Allow-Methods' 'GET';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+        add_header 'X-Content-Type-Options' 'nosniff';
+        add_header 'Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+        add_header 'X-Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+        add_header 'X-XSS-Protection' '1; mode=block';
+
+        proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
+
+        proxy_redirect         /$host/ /;
+        proxy_cache            STATIC;
+        proxy_cache_valid      200  1d;
+        proxy_cache_use_stale  error timeout invalid_header updating
+                    http_500 http_502 http_503 http_504;
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Credentials;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+
+        # Contents of proxy.conf, updated to AZ
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.seafloorexplorer.org$request_uri;
+
+        # This is a hack to get nginx to discard the uri in the proxy request
+        set $uri_path "www.seafloorexplorer.org/";
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$uri_path;
+    }
 }

--- a/sites/www.seafloorexplorer.org.conf
+++ b/sites/www.seafloorexplorer.org.conf
@@ -12,7 +12,7 @@ server {
         proxy_http_version 1.1;
 
         add_header 'X-Content-Type-Options' 'nosniff';
-        add_header 'Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+        add_header 'Content-Security-Policy' "frame-ancestors 'self'";
         add_header 'X-Content-Security-Policy' "frame-ancestors 'self'";
         add_header 'X-XSS-Protection' '1; mode=block';
 

--- a/sites/www.seafloorexplorer.org.conf
+++ b/sites/www.seafloorexplorer.org.conf
@@ -13,7 +13,7 @@ server {
 
         add_header 'X-Content-Type-Options' 'nosniff';
         add_header 'Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
-        add_header 'X-Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+        add_header 'X-Content-Security-Policy' "frame-ancestors 'self'";
         add_header 'X-XSS-Protection' '1; mode=block';
 
         proxy_cache            STATIC;

--- a/sites/www.seafloorexplorer.org.conf
+++ b/sites/www.seafloorexplorer.org.conf
@@ -2,6 +2,10 @@ server {
     include /etc/nginx/ssl.default.conf;
     server_name www.seafloorexplorer.org;
 
+    location /subjects/ {
+        return 301 https://s3.amazonaws.com/$host$request_uri;
+    }
+
     location / {
         resolver 8.8.8.8;
         proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;


### PR DESCRIPTION
This is an experiment to serve static assets from Azure instead of S3. It's a part of a bigger effort to rethink deployment, CI/CD, and hosting of static assets.

Couple things:

* Deleted the /server/ location block because a) there's no subjects in the bucket to serve and b) the redirect didn't make sense (https://s3.amazonaws.com/$host$request_uri surely doesn't exist). 
* Copied over all the headers in the way that batdetective.org did, changing the one I needed to change and leaving the rest. How many of these are necessary in Az vs S3, I do not yet know.
* Left in the hack to write the URI to a var since nginx does something weird with it. I'm wondering if it has to do with the trailing slash? Azure behaves a little different than S3 in that regard: (http://blog.brianbeach.com/posts/2020-01-08-cloud-storage-trailing-slashes/)

See https://github.com/zooniverse/operations/issues/494 for plan details.