### PR TITLE
Fix test http response stage in jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "docker logs ${nginx_c.id}"
             docker.image('alpine').inside("-u 0 --link ${nginx_c.id}:nginx") {
               sh "apk add --no-cache curl"
-              sh "curl -vk https://nginx/index.html"
+              sh "curl -vk http://nginx/index.html"
             }
           }
         }

--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ Note: You must provide a host when testing locally or the implicit `localhost` h
 
 Read more at the [Nginx request processing docs](http://nginx.org/en/docs/http/request_processing.html)
 
+#### Simulate the jenkins test step
+
+Use the `test-http` image to replicate the jenkins `Test HTTP response` stage. Uncomment the `test-http` conatiner in the docker-compose yaml.
+
+``` bash
+docker-compose run --rm test-http
+# in the alpine conatiner install curl
+apk add --no-cache curl
+# and test a request to nginx static image
+curl -vk http://nginx/index.html
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:80"
+  # test-http:
+  #   image: alpine
+  #   links:
+  #     - static:nginx


### PR DESCRIPTION
static no longer listens on port 443 (https) since switching the underlying docker image to the official build, https://github.com/zooniverse/docker-nginx/commit/017efff71c69937076bcca86e250d8dac0cbe161

Note all our TLS / SSL termination happens at the k8s nginx-ingress and behind that our services run on http only (including this service).

As such this PR switches the jenkins `test http response` build stage to use the `http` protocol to ensure the image works before deploying. 

Finally this PR adds a test harness via compose / readme instructions to replicate the jenkins `test http response` build stage by adding an alpine image (commented out by default) and the steps to run the test as jenkins does. 