### PR TITLE
Add *.azure.zooniverse.org conf

### DIFF
--- a/sites/star.azure.zooniverse.org.conf
+++ b/sites/star.azure.zooniverse.org.conf
@@ -8,7 +8,7 @@ server {
         proxy_http_version 1.1;
 
         # This should point to static.zooniverse.org after the full DNS switch is complete
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/$subdomain$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/$subdomain.zooniverse.org$request_uri;
 
         add_header 'X-Content-Type-Options' 'nosniff';
         add_header 'Content-Security-Policy' "frame-ancestors 'self'";
@@ -19,6 +19,6 @@ server {
         proxy_cache_use_stale  error timeout invalid_header updating
                     http_500 http_502 http_503 http_504;
 
-        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$subdomain;
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$subdomain.zooniverse.org$request_uri/;
     }
 }

--- a/sites/star.azure.zooniverse.org.conf
+++ b/sites/star.azure.zooniverse.org.conf
@@ -1,0 +1,24 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name "~^(?P<subdomain>.*)\.azure\.zooniverse\.org$";
+
+    location / {
+        resolver 8.8.8.8;
+        proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
+        proxy_http_version 1.1;
+
+        # This should point to static.zooniverse.org after the full DNS switch is complete
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/$subdomain$request_uri;
+
+        add_header 'X-Content-Type-Options' 'nosniff';
+        add_header 'Content-Security-Policy' "frame-ancestors 'self'";
+        add_header 'X-Content-Security-Policy' "frame-ancestors 'self'";
+        add_header 'X-XSS-Protection' '1; mode=block';
+        proxy_cache            STATIC;
+        proxy_cache_valid      200  1d;
+        proxy_cache_use_stale  error timeout invalid_header updating
+                    http_500 http_502 http_503 http_504;
+
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$subdomain;
+    }
+}


### PR DESCRIPTION
Modeled after the conf for star.preview, this is to allow accessing static files in Azure (directly, rather than through static.zooniverse.org or directly to S3) via a subdomain prefix to any host served by the http frontend.

Props to @camallen for the clever way around a PR every time I want to try a new site.