### PR TITLE
Add *.azure.zooniverse.org to TLS hosts

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -16,6 +16,7 @@ spec:
     - "*.preview.zooniverse.org"
     - "*.pfe-preview.zooniverse.org"
     - "*.lab-preview.zooniverse.org"
+    - "*.azure.zooniverse.org"
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -36,6 +37,7 @@ spec:
     - "*.preview.zooniverse.org"
     - "*.pfe-preview.zooniverse.org"
     - "*.lab-preview.zooniverse.org"
+    - "*.azure.zooniverse.org"
     secretName: zooniverse-org-tls
   rules:
   - host: zooniverse.org
@@ -74,6 +76,13 @@ spec:
           servicePort: 80
         path: /(.*)
   - host: "*.lab-preview.zooniverse.org"
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend
+          servicePort: 80
+        path: /(.*)
+  - host: "*.azure.zooniverse.org"
     http:
       paths:
       - backend:


### PR DESCRIPTION
Required for sites that require logging in to use, turns out this is most of them. Will also presumably have to add the new host to the Doorkeeper app whitelist.