### PR TITLE
add subject-assitant-proxy to zooniverse ingress

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -89,3 +89,10 @@ spec:
           serviceName: http-frontend
           servicePort: 80
         path: /(.*)
+  - host: subject-assistant-proxy.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: subject-assistant-proxy
+          servicePort: 80
+        path: /(.*)


### PR DESCRIPTION
move the subject assistant proxy to zooniverse ingress and re-use the *.zooniverse.org tls cert.

This is first of a set of service ingress changes to consolidate the *.zooniverse.org service domains onto the *.zooniverse.org tls cert and use the DNS solver to issue these certs. 

This simplifies the tls cert and avoids any service HTTP error codes (404, 500 etc) when using the HTTP solver on the TLS ingress.