### PR TITLE
Serve Lab from Azure

### DIFF
--- a/sites/lab.zooniverse.org.conf
+++ b/sites/lab.zooniverse.org.conf
@@ -2,20 +2,24 @@ server {
     include /etc/nginx/ssl.default.conf;
     server_name lab.zooniverse.org;
 
-    location ~ \.(js|css)$ {
-        resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/lab.zooniverse.org$request_uri;
-        include /etc/nginx/proxy-headers.conf;
-    }
-
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/lab.zooniverse.org$request_uri;
-
         resolver 8.8.8.8;
+        proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
+        proxy_http_version 1.1;
+
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/lab.zooniverse.org$request_uri;
+
+        add_header 'X-Content-Type-Options' 'nosniff';
+        add_header 'Content-Security-Policy' "frame-ancestors 'self'";
+        add_header 'X-Content-Security-Policy' "frame-ancestors 'self'";
+        add_header 'X-XSS-Protection' '1; mode=block';
+        proxy_cache            STATIC;
+        proxy_cache_valid      200  1d;
+        proxy_cache_use_stale  error timeout invalid_header updating
+                    http_500 http_502 http_503 http_504;
 
         # This is a hack to get nginx to discard the uri in the proxy request
         set $uri_path "lab.zooniverse.org/";
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$uri_path;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass             http://zooniversestatic.z13.web.core.windows.net/$uri_path;
     }
 }


### PR DESCRIPTION
The first soup to nuts Azure/gitops deployment. I'm not sure this change here will serve anything but the landing page (due to how the redirects are set up to zooniverse.org/lab) until we move over zooniverse.org as a whole, though.

Staging: PR->GH Action->staging branch deploy->slack output
Production: Lita->jenkins->tag->merge->GH Action->production deploy->slack