### PR TITLE
Add staging-->azure server block for ALICE

### DIFF
--- a/sites/alice.zooniverse.org.conf
+++ b/sites/alice.zooniverse.org.conf
@@ -19,19 +19,3 @@ server {
       include /etc/nginx/proxy-headers.conf;
   }
 }
-
-# Temporary location to view staging on Azure (extra subdomain doesn't work w/ *.preview)
-server {
-  include /etc/nginx/ssl.default.conf;
-  server_name alice.azure.zooniverse.org;
-
-  location / {
-      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-      rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/alice/$request_uri;
-
-      resolver 8.8.8.8;
-
-      include /etc/nginx/az-proxy-headers.conf;
-      proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/alice/;
-  }
-}

--- a/sites/alice.zooniverse.org.conf
+++ b/sites/alice.zooniverse.org.conf
@@ -19,3 +19,30 @@ server {
       include /etc/nginx/proxy-headers.conf;
   }
 }
+
+# Temporary location to view staging on Azure (extra subdomain doesn't work w/ *.preview)
+server {
+  include /etc/nginx/ssl.default.conf;
+  server_name alice.azure.zooniverse.org;
+
+  location / {
+      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
+      rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/alice/$request_uri;
+
+      resolver 8.8.8.8;
+
+    # Soon to be replaced with az-proxy-headers.conf
+      proxy_http_version 1.1;
+      add_header 'X-Content-Type-Options' 'nosniff';
+      add_header 'Content-Security-Policy' "frame-ancestors 'self'";
+      add_header 'X-Content-Security-Policy' "frame-ancestors 'self'";
+      add_header 'X-XSS-Protection' '1; mode=block';
+      proxy_cache            STATIC;
+      proxy_cache_valid      200  1d;
+      proxy_cache_use_stale  error timeout invalid_header updating
+                  http_500 http_502 http_503 http_504;
+
+      proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/alice/;
+      include /etc/nginx/az-proxy-headers.conf;
+  }
+}

--- a/sites/alice.zooniverse.org.conf
+++ b/sites/alice.zooniverse.org.conf
@@ -43,6 +43,6 @@ server {
                   http_500 http_502 http_503 http_504;
 
       proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/alice/;
-      include /etc/nginx/az-proxy-headers.conf;
+      include /etc/nginx/proxy-headers.conf;
   }
 }

--- a/sites/alice.zooniverse.org.conf
+++ b/sites/alice.zooniverse.org.conf
@@ -31,17 +31,7 @@ server {
 
       resolver 8.8.8.8;
 
-    # Soon to be replaced with az-proxy-headers.conf
-      proxy_http_version 1.1;
-      add_header 'X-Content-Type-Options' 'nosniff';
-      add_header 'Content-Security-Policy' "frame-ancestors 'self'";
-      add_header 'X-Content-Security-Policy' "frame-ancestors 'self'";
-      add_header 'X-XSS-Protection' '1; mode=block';
-      proxy_cache            STATIC;
-      proxy_cache_valid      200  1d;
-      proxy_cache_use_stale  error timeout invalid_header updating
-                  http_500 http_502 http_503 http_504;
-
+      include /etc/nginx/az-proxy-headers.conf;
       proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/alice/;
   }
 }

--- a/sites/alice.zooniverse.org.conf
+++ b/sites/alice.zooniverse.org.conf
@@ -43,6 +43,5 @@ server {
                   http_500 http_502 http_503 http_504;
 
       proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/alice/;
-      include /etc/nginx/proxy-headers.conf;
   }
 }

--- a/sites/star.preview.zooniverse.org.conf
+++ b/sites/star.preview.zooniverse.org.conf
@@ -4,17 +4,12 @@ server {
 
     include /etc/nginx/api-proxy.conf;
 
-    location ~ \.(js|css)$ {
-        resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/$subdomain$request_uri;
-        include /etc/nginx/proxy-headers.conf;
-    }
-
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/preview.zooniverse.org/$subdomain$request_uri;
+      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/$subdomain$request_uri;
 
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/preview.zooniverse.org/$subdomain$request_uri;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/$subdomain$request_uri;
+        include /etc/nginx/az-proxy-headers.conf;
     }
 }


### PR DESCRIPTION
The *.azure.zooniverse.org trick doesn't work with the extra subdomain @ alice.azure.zooniverse.org. I added an extra server block here just to test, but this won't last long. I'd like to confirm that the Az version works as expected, then serve prod and staging both from Az tomorrow.