### PR TITLE
increase the client request payload to 6m

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -27,6 +27,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/proxy-body-size: 6m
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
   tls:


### PR DESCRIPTION
ensure our lambda forwarders (max 6MB) can successfully post data through our ingress to our target end points (caesar | graphql-stats)

related to https://github.com/zooniverse/operations/pull/504/