### PR TITLE
add classroom-maps-api.zooniverse.org ingress

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -125,6 +125,13 @@ spec:
           serviceName: cellect-production-app
           servicePort: 80
         path: /(.*)
+  - host: classroom-maps-api.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: classroom-maps-api-production-app
+          servicePort: 80
+        path: /(.*)
   - host: designator-staging.zooniverse.org
     http:
       paths:


### PR DESCRIPTION
linked to https://github.com/zooniverse/classroom-maps-api/pull/4

this will tie the classroom-maps-api.zooniverse.org to the main *.zooniverse.org ingress & certificate