### PR TITLE
🚨 Update fallback proxy conf to point to Azure 🚨 

### DIFF
--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -1,9 +1,10 @@
 include /etc/nginx/api-proxy.conf;
 
 location / {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$host$request_uri;
+    # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
+    rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
 
     resolver 8.8.8.8;
-    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;
+    proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
     include /etc/nginx/proxy-headers.conf;
 }

--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -6,5 +6,5 @@ location / {
 
     resolver 8.8.8.8;
     proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
-    include /etc/nginx/proxy-headers.conf;
+    include /etc/nginx/az-proxy-headers.conf;
 }


### PR DESCRIPTION
Updates nginx-proxy.conf to point to Azure and use the az headers. This will flip the switch from S3 to Azure on everything that doesn't have an explicit conf that is matching its server name. 

When this merges, do a lot of testing. Then there's a few cleanup steps [detailed here](https://github.com/zooniverse/operations/issues/494), but relevant here is that there are some remainder conf files that point to S3 that need to be updated, and this PR will make some confs that point to Azure already extraneous. 