### PR TITLE
serve JS and CSS assets from the host domain

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -83,9 +83,17 @@ server {
         return 301 /projects/arolsen-archives/every-name-counts$1$2$is_args$query_string;
     }
 
+    # ensure the js and CSS assets are served on the same or subdomain
+    # switch back to redirecet once they are served from the static.zooniverse.org domain
+    location ~ \.(js|css)$ {
+        resolver 8.8.8.8;
+        proxy_pass  https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
+        include /etc/nginx/az-proxy-headers.conf;
+    }
+
     location / {
         # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|json|js|css)$ https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
 
         resolver 8.8.8.8;
         if ($request_method ~ ^(GET|HEAD)$) {


### PR DESCRIPTION
Fixes the changes added in #220 to not server JS/CSS assets on non zoonivese, third party domains (azure owned).

Serving assets via 302 redirects on these third party domains causes some client computers with 3rd party security scanners to block loading the JS assets as phishing attempts, specifically Trend Micro with details reported at https://www.zooniverse.org/talk/17/1942061?comment=3162343

Generally we should always serve these assets on the same domain or subdomain as the host. In this case on the www.zooniverse.org domain as it has it's own CDN via nginx proxy_pass and rely on the CDN to handle caching etc.

On a case by case basis in future if the host domain has it's own CDN use the proxy pass technique. Alternatively use the static.zooniverse.org/$host domain as it has a CDN to distribute important web assets for us on our own trusted subdomain.