### PR TITLE
Fix API paths for subject-set-search-api

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -306,7 +306,7 @@ spec:
       - backend:
           serviceName: subject-set-search-api-production-app
           servicePort: 80
-        path: /
+        path: /(.*)
   - host: theia-staging.zooniverse.org
     http:
       paths:


### PR DESCRIPTION
Add the path regex so that URLs don't redirect to the Datasette home page.