### PR TITLE
Switch to Azure CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 static
 ======
 
-An nginx caching proxy (mostly) for serving static sites from S3.
+An nginx caching proxy (mostly) for serving static sites from Azure Blob Storage.
 
 Run it locally with Docker:
 

--- a/nginx-az-proxy-headers.conf
+++ b/nginx-az-proxy-headers.conf
@@ -1,3 +1,4 @@
+proxy_ssl_server_name on;
 proxy_http_version 1.1;
 add_header 'X-Content-Type-Options' 'nosniff';
 add_header 'Content-Security-Policy' "frame-ancestors 'self'";

--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -1,7 +1,7 @@
 include /etc/nginx/api-proxy.conf;
 
 location / {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$host$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/$host$request_uri;
 
     resolver 8.8.8.8;
     proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;

--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -4,6 +4,6 @@ location / {
     rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/$host$request_uri;
 
     resolver 8.8.8.8;
-    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;
-    include /etc/nginx/proxy-headers.conf;
+    proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
+    include /etc/nginx/az-proxy-headers.conf;
 }

--- a/sites/alice.zooniverse.org.conf
+++ b/sites/alice.zooniverse.org.conf
@@ -5,8 +5,7 @@ server {
   location / {
       resolver 8.8.8.8;
 
-      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/alice.zooniverse.org$request_uri;
+      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/alice.zooniverse.org$request_uri;
 
       # This is a hack to get nginx to discard the uri in the proxy request
       set $uri_path "alice.zooniverse.org/";

--- a/sites/classroom.zooniverse.org.conf
+++ b/sites/classroom.zooniverse.org.conf
@@ -5,8 +5,7 @@ server {
   location / {
       resolver 8.8.8.8;
 
-      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/classroom.zooniverse.org$request_uri;
+      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/classroom.zooniverse.org$request_uri;
 
       # This is a hack to get nginx to discard the uri in the proxy request
       set $uri_path "classroom.zooniverse.org/";

--- a/sites/field-book-preview.notesfromnature.org.conf
+++ b/sites/field-book-preview.notesfromnature.org.conf
@@ -5,8 +5,7 @@ server {
     location / {
         resolver 8.8.8.8;
 
-        # This should point to static.zooniverse.org after the full DNS switch is complete
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/field-book-preview.notesfromnature.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/field-book-preview.notesfromnature.org$request_uri;
 
         include /etc/nginx/az-proxy-headers.conf;
 

--- a/sites/field-book.notesfromnature.org.conf
+++ b/sites/field-book.notesfromnature.org.conf
@@ -5,8 +5,7 @@ server {
     location / {
         resolver 8.8.8.8;
 
-        # This should point to static.zooniverse.org after the full DNS switch is complete
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/field-book.notesfromnature.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/field-book.notesfromnature.org$request_uri;
 
         include /etc/nginx/az-proxy-headers.conf;
 

--- a/sites/invalid-paths.ouroboros.talk.conf
+++ b/sites/invalid-paths.ouroboros.talk.conf
@@ -33,9 +33,9 @@ server {
     rewrite ^(.+?)\.(\/.*)?$      /$host$1_$2 break;
 
     resolver 8.8.8.8;
-    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com;
+    proxy_pass             https://zooniversestatic.z13.web.core.windows.net;
 
-    include /etc/nginx/proxy-headers.conf;
+    include /etc/nginx/az-proxy-headers.conf;
   }
 
   # this location serves all other pages on the above domain
@@ -45,7 +45,7 @@ server {
     rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$host$request_uri;
 
     resolver 8.8.8.8;
-    proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;
-    include /etc/nginx/proxy-headers.conf;
+    proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
+    include /etc/nginx/az-proxy-headers.conf;
   }
 }

--- a/sites/lab.zooniverse.org.conf
+++ b/sites/lab.zooniverse.org.conf
@@ -6,8 +6,7 @@ server {
         resolver 8.8.8.8;
         proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
 
-        # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/lab.zooniverse.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/lab.zooniverse.org$request_uri;
 
         include /etc/nginx/az-proxy-headers.conf;
 

--- a/sites/lab.zooniverse.org.conf
+++ b/sites/lab.zooniverse.org.conf
@@ -4,7 +4,6 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
 
         rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/lab.zooniverse.org$request_uri;
 

--- a/sites/login.zooniverse.org.conf
+++ b/sites/login.zooniverse.org.conf
@@ -2,17 +2,11 @@ server {
     include /etc/nginx/ssl.default.conf;
     server_name login.zooniverse.org;
 
-    location ~ \.(js|css)$ {
-        resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;
-        include /etc/nginx/proxy-headers.conf;
-    }
-
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$host$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/$host$request_uri;
 
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host/;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host/;
+        include /etc/nginx/az-proxy-headers.conf;
     }
 }

--- a/sites/penguinwatch.org.conf
+++ b/sites/penguinwatch.org.conf
@@ -21,7 +21,7 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.penguinwatch.org$request_uri;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/www.penguinwatch.org$request_uri;
+        include /etc/nginx/az-proxy-headers.conf;
     }
 }

--- a/sites/planethunters.org.conf
+++ b/sites/planethunters.org.conf
@@ -29,7 +29,7 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/www.planethunters.org$request_uri;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/www.planethunters.org$request_uri;
+        include /etc/nginx/az-proxy-headers.conf;
     }
 }

--- a/sites/relaunch.notesfromnature.org.conf
+++ b/sites/relaunch.notesfromnature.org.conf
@@ -2,20 +2,14 @@ server {
     include /etc/nginx/ssl.default.conf;
     server_name relaunch.notesfromnature.org;
 
-    location ~ \.(js|css)$ {
-        resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/relaunch.notesfromnature.org$request_uri;
-        include /etc/nginx/proxy-headers.conf;
-    }
-
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/relaunch.notesfromnature.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/relaunch.notesfromnature.org$request_uri;
 
         resolver 8.8.8.8;
 
         # This is a hack to get nginx to discard the uri in the proxy request
         set $uri_path "relaunch.notesfromnature.org/";
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$uri_path;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$uri_path;
+        include /etc/nginx/az-proxy-headers.conf;
     }
 }

--- a/sites/spacewarps.org.conf
+++ b/sites/spacewarps.org.conf
@@ -21,7 +21,7 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/spacewarps.org$request_uri;
-        include /etc/nginx/proxy-headers.conf;
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/spacewarps.org$request_uri;
+        include /etc/nginx/az-proxy-headers.conf;
     }
 }

--- a/sites/star.azure.zooniverse.org.conf
+++ b/sites/star.azure.zooniverse.org.conf
@@ -4,7 +4,6 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
 
         rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/$subdomain.zooniverse.org$request_uri;
 

--- a/sites/star.azure.zooniverse.org.conf
+++ b/sites/star.azure.zooniverse.org.conf
@@ -6,8 +6,7 @@ server {
         resolver 8.8.8.8;
         proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
 
-        # This should point to static.zooniverse.org after the full DNS switch is complete
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/$subdomain.zooniverse.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/$subdomain.zooniverse.org$request_uri;
 
         include /etc/nginx/az-proxy-headers.conf;
 

--- a/sites/star.lab-preview.zooniverse.org.conf
+++ b/sites/star.lab-preview.zooniverse.org.conf
@@ -3,8 +3,7 @@ server {
     server_name "~^(?P<subdomain>.*)\.lab-preview\.zooniverse\.org$";
 
     location / {
-        # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/pfe-lab/$subdomain$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/pfe-lab/$subdomain$request_uri;
 
         resolver 8.8.8.8;
         proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/pfe-lab/$subdomain/;
@@ -17,8 +16,7 @@ server {
     server_name lab-preview.zooniverse.org;
 
     location / {
-        # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/pfe-lab$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/pfe-lab$request_uri;
 
         resolver 8.8.8.8;
 

--- a/sites/star.pfe-preview.zooniverse.org.conf
+++ b/sites/star.pfe-preview.zooniverse.org.conf
@@ -4,8 +4,7 @@ server {
     server_name "~^(?P<subdomain>.*)\.pfe-preview\.zooniverse\.org$";
 
     location / {
-        # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/panoptes-front-end/$subdomain$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/panoptes-front-end/$subdomain$request_uri;
 
         resolver 8.8.8.8;
         proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/panoptes-front-end/$subdomain/;
@@ -19,8 +18,7 @@ server {
     server_name pfe-preview.zooniverse.org;
 
     location / {
-        # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/panoptes-front-end$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/panoptes-front-end$request_uri;
 
         resolver 8.8.8.8;
 

--- a/sites/star.preview.zooniverse.org.conf
+++ b/sites/star.preview.zooniverse.org.conf
@@ -5,8 +5,7 @@ server {
     include /etc/nginx/api-proxy.conf;
 
     location / {
-      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/$subdomain$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/$subdomain$request_uri;
 
         resolver 8.8.8.8;
         proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/$subdomain$request_uri;

--- a/sites/translations.zooniverse.org.conf
+++ b/sites/translations.zooniverse.org.conf
@@ -5,8 +5,7 @@ server {
   location / {
       resolver 8.8.8.8;
 
-      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/translations.zooniverse.org$request_uri;
+      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/translations.zooniverse.org$request_uri;
 
       # This is a hack to get nginx to discard the uri in the proxy request
       set $uri_path "translations.zooniverse.org/";
@@ -22,8 +21,7 @@ server {
   location / {
       resolver 8.8.8.8;
 
-      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/pandora.zooniverse.org$request_uri;
+      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/pandora.zooniverse.org$request_uri;
 
       # This is a hack to get nginx to discard the uri in the proxy request
       set $uri_path "pandora.zooniverse.org/";

--- a/sites/www.antislaverymanuscripts.org.conf
+++ b/sites/www.antislaverymanuscripts.org.conf
@@ -4,7 +4,6 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
 
         rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/www.antislaverymanuscripts.org$request_uri;
 

--- a/sites/www.antislaverymanuscripts.org.conf
+++ b/sites/www.antislaverymanuscripts.org.conf
@@ -6,8 +6,7 @@ server {
         resolver 8.8.8.8;
         proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
 
-        # This should point to static.zooniverse.org after the full DNS switch is complete
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/www.antislaverymanuscripts.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/www.antislaverymanuscripts.org$request_uri;
 
         include /etc/nginx/az-proxy-headers.conf;
 

--- a/sites/www.batdetective.org.conf
+++ b/sites/www.batdetective.org.conf
@@ -5,7 +5,7 @@ server {
     location /talk-player/ {
         resolver 8.8.8.8;
         proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
-        proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
+        proxy_set_header       Host https://zooniversestatic.z13.web.core.windows.net;
         proxy_redirect         /$host/ /;
         include /etc/nginx/az-proxy-headers.conf;
     }

--- a/sites/www.batdetective.org.conf
+++ b/sites/www.batdetective.org.conf
@@ -5,7 +5,6 @@ server {
     location /talk-player/ {
         resolver 8.8.8.8;
         proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
-        proxy_set_header       Host https://zooniversestatic.z13.web.core.windows.net;
         proxy_redirect         /$host/ /;
         include /etc/nginx/az-proxy-headers.conf;
     }

--- a/sites/www.batdetective.org.conf
+++ b/sites/www.batdetective.org.conf
@@ -4,25 +4,10 @@ server {
 
     location /talk-player/ {
         resolver 8.8.8.8;
-        proxy_pass             http://zooniverse-static.s3-website-us-east-1.amazonaws.com/$host$request_uri;
-        # Exclude X-Frame-Options header
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Credentials' 'true';
-        add_header 'Access-Control-Allow-Methods' 'GET';
-        add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-        add_header 'X-Content-Type-Options' 'nosniff';
-        add_header 'X-XSS-Protection' '1; mode=block';
-
+        proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
         proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;
         proxy_redirect         /$host/ /;
-        proxy_cache            STATIC;
-        proxy_cache_valid      200  1d;
-        proxy_cache_use_stale  error timeout invalid_header updating
-                    http_500 http_502 http_503 http_504;
-        proxy_hide_header Access-Control-Allow-Origin;
-        proxy_hide_header Access-Control-Allow-Credentials;
-        proxy_hide_header Access-Control-Allow-Methods;
-        proxy_hide_header Access-Control-Allow-Headers;
+        include /etc/nginx/az-proxy-headers.conf;
     }
 
     include /etc/nginx/proxy.conf;

--- a/sites/www.scribesofthecairogeniza.org.conf
+++ b/sites/www.scribesofthecairogeniza.org.conf
@@ -5,8 +5,7 @@ server {
     location / {
       resolver 8.8.8.8;
 
-      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/www.scribesofthecairogeniza.org$request_uri;
+      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/www.scribesofthecairogeniza.org$request_uri;
 
       # This is a hack to get nginx to discard the uri in the proxy request
       set $uri_path "www.scribesofthecairogeniza.org/";

--- a/sites/www.seafloorexplorer.org.conf
+++ b/sites/www.seafloorexplorer.org.conf
@@ -8,7 +8,6 @@ server {
 
     location / {
         resolver 8.8.8.8;
-        proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
 
         rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/www.seafloorexplorer.org$request_uri;
 

--- a/sites/www.seafloorexplorer.org.conf
+++ b/sites/www.seafloorexplorer.org.conf
@@ -10,8 +10,7 @@ server {
         resolver 8.8.8.8;
         proxy_set_header       Host zooniversestatic.z13.web.core.windows.net;
 
-        # This should point to static.zooniverse.org after the full DNS switch is complete
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/www.seafloorexplorer.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|woff|ttf|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/www.seafloorexplorer.org$request_uri;
 
         include /etc/nginx/az-proxy-headers.conf;
 

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -92,8 +92,7 @@ server {
     }
 
     location / {
-        # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$host$request_uri;
 
         resolver 8.8.8.8;
         if ($request_method ~ ^(GET|HEAD)$) {
@@ -104,7 +103,6 @@ server {
             proxy_pass             https://panoptes.zooniverse.org$request_uri;
             set $proxy_host_header "panoptes.zooniverse.org";
         }
-        proxy_set_header       Host $proxy_host_header;
         proxy_redirect         /$host/ /;
 
         include /etc/nginx/az-proxy-headers.conf;

--- a/sites/zoo-notes.zooniverse.org.conf
+++ b/sites/zoo-notes.zooniverse.org.conf
@@ -5,7 +5,6 @@ server {
   location / {
       resolver 8.8.8.8;
 
-      # TODO: Long term ensure this eventually points to `static.zooniverse.org` CDN domain for CDN benefits
       rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/zoo-notes.zooniverse.org$request_uri;
 
       # This is a hack to get nginx to discard the uri in the proxy request

--- a/sites/zoo-notes.zooniverse.org.conf
+++ b/sites/zoo-notes.zooniverse.org.conf
@@ -5,7 +5,7 @@ server {
   location / {
       resolver 8.8.8.8;
 
-      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://zooniversestatic.z13.web.core.windows.net/zoo-notes.zooniverse.org$request_uri;
+      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/zoo-notes.zooniverse.org$request_uri;
 
       # This is a hack to get nginx to discard the uri in the proxy request
       set $uri_path "zoo-notes.zooniverse.org/";


### PR DESCRIPTION
1st commit: individual sites switch their rewrites to static.zooniverse.org/$whatever. I did not reintroduce the JS/CSS-specific location blocks because I can't think of a reason that, now that the rewrite will be pointing at a zooniverse.org domain, that we wouldn't want  to cache these at the CDN.

2nd commit: Add js|css to the fallback nginx conf. See above.

3rd commit: Clean up remaining pointers to S3. Most of are currently broken anyway (old.penguinwatch.org, kepler.planethunters.org, relaunch.notesfromnature.org and batdetective.org/talk-player... old.spacewarps.org works, though!). Changed proxy_set_headers where they existed, unsure if these are necessary.

The nginx-proxy.conf proxy_pass and the zooniverse.org rewrite will be handled by the other PR (https://github.com/zooniverse/static/pull/221)

Things I left alone: 
	seafloorexplorer.org/subjects
	data.zooniverse.org
	developer.zooniverse.org
	oldweather.org seems to have its own bucket
	All of the zooniverse-resources links in nginx-redirects.conf: not sure if these got copied over or not.