### PR TITLE
reinstate www.zooniverse.org/unsubscribe page behaviours

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -90,6 +90,27 @@ server {
         include /etc/nginx/az-proxy-headers.conf;
     }
 
+    # unsubscribe route uses redirects between panoptes and the UI code
+    # so needs it's own location block to handle the form submission POST
+    # and the GET page loading (PFE routing handles the path)
+    location /unsubscribe {
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$host$request_uri;
+
+        resolver 8.8.8.8;
+        if ($request_method ~ ^(GET|HEAD)$) {
+            proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host/;
+            set $proxy_host_header "zooniversestatic.z13.web.core.windows.net";
+        }
+        if ($request_method = POST) {
+            proxy_pass             https://panoptes.zooniverse.org$request_uri;
+            set $proxy_host_header "panoptes.zooniverse.org";
+        }
+        proxy_set_header Host $proxy_host_header;
+        proxy_redirect         /$host/ /;
+
+        include /etc/nginx/az-proxy-headers.conf;
+    }
+
     location / {
         rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$host$request_uri;
 


### PR DESCRIPTION
This PR reinstates the unsubscribe form submission behaviour accidentally removed in #226

the `www.zooniverse.org/unsubscribe` paths have slightly complex redirect behaviour at the API so we can't use the CDN (AFD) to proxy these requests directly to the API as we end up in a redirect loop on get requests. Instead this PR 
- ensures the GET loads the PFE code page out of azure blob  storage
- and the form submission POST request is served by panoptes

Longer term we may look at removing the `API GET /unsubscribe` behaviour or use that on a different domain URL (not www.zooniverse.org).