### PR TITLE
Slower ingress file deploys to the k8s ingress pods

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,16 @@ pipeline {
       agent any
       steps {
         sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl --context azure apply --record -f -"
-        sh "kubectl --context azure apply --record -f kubernetes/ingress/"
+        sh ""
+        sh '''#!/bin/bash
+              for ingress in kubernetes/ingress/*
+              do
+                kubectl --context azure apply --record -f $ingress
+                pause=$[($RANDOM % 10 ) + 1]
+                # echo "sleeping a random value of 0.${pause} seconds"
+                sleep .${pause}s
+              done
+           '''
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
       agent any
       steps {
         sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl --context azure apply --dry-run=client --record -f -"
-        sh "for ingress in kubernetes/ingress/*; do kubectl --context azure apply --dry-run=client --record -f ${ingress} && sleep .$[ ( $RANDOM % 10 ) + 1 ]s; done"
+        sh "kubectl --context azure apply --dry-run=client --record -f kubernetes/ingress/"
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
       agent any
       steps {
         sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl --context azure apply --dry-run=client --record -f -"
-        sh "kubectl --context azure apply --dry-run=client --record -f kubernetes/ingress/"
+        sh "for ingress in kubernetes/ingress/*; do kubectl --context azure apply --dry-run=client --record -f ${ingress} && sleep .$[ ( $RANDOM % 10 ) + 1 ]s; done"
       }
     }
 


### PR DESCRIPTION
this PR attempts to slow the rate of ingress changes being applied to the cluster during deploys. It introduces a loop over the ingress files and attempts to apply the ingress definition files 1 by 1 with a random pause between 0 - 1 seconds after each file has been applied. 

This should help alleviate the rate of change in the ingress pods and thus decrease the IO operations on the k8s nodes. Finally we can easily increase this pause between files to space out the ingress apply operations and thus decrease the IO pressure on the k8s nodes (though mean longer deploys).