### PR TITLE
Serve chimpandsee subject data from S3

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -335,19 +335,6 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name chimpandsee.org www.chimpandsee.org;
-
-    location /subjects/ {
-        return 301 https://static.zooniverse.org/$host$request_uri;
-    }
-
-    location / {
-        return 301 https://www.zooniverse.org/projects/sassydumbledore/chimp-and-see;
-    }
-}
-
-server {
-    include /etc/nginx/ssl.default.conf;
     server_name blogs.zooniverse.org;
     rewrite ^/solarstormwatch/files/(.*) http://zooniverse-resources.s3.amazonaws.com/blogs.zooniverse.org/3/files/$1 last;
     rewrite ^/mwp/files/(.*) http://zooniverse-resources.s3.amazonaws.com/blogs.zooniverse.org/10/files/$1 last;

--- a/sites/chimpandsee.org.conf
+++ b/sites/chimpandsee.org.conf
@@ -1,0 +1,14 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name chimpandsee.org www.chimpandsee.org;
+
+    # Full migration of assets was somewhat less than successful,
+    # so serve subject data from S3 for now.
+    location /subjects/ {
+        return 301 https://zooniverse-static.s3.amazonaws.com/www.chimpandsee.org/$request_uri;
+    }
+
+    location / {
+        return 301 https://www.zooniverse.org/projects/sassydumbledore/chimp-and-see;
+    }
+}


### PR DESCRIPTION
Asset migration from S3 to Azure wasn't nearly as complete as was believed. The canonical data still lives on S3 and this project team requires access to these subjects' data, so this is a bandage to allow the subjects to load in the talk archive and elsewhere until we set aside a block of time in our planned efforts to finalize this element of Azure migration. 