### PR TITLE
adds per project URLs that proxy to fe-project nextjs app

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -1,3 +1,10 @@
+upstream k8s-fe-project {
+  # the service name in k8s (http)
+  server zooniverse-org-project-production;
+  # use the below when external k8s cluster URL (testing) via HTTPS
+  # server fe-project.zooniverse.org;
+}
+
 server {
     set $csp_whitelist "zooniverse.org *.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
@@ -87,7 +94,7 @@ server {
         return 301 /projects/laac-lscp/maturity-of-baby-sounds$1$2$is_args$query_string;
     }
 
-    set $fe_project_uri "https://fe-project.zooniverse.org";
+    set $fe_project_uri "http://k8s-fe-project";
     location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:classify(?:/.+?)?)?/?$ {
         resolver 8.8.8.8;
         proxy_pass $fe_project_uri;

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -89,7 +89,7 @@ server {
 
     set $fe_project_uri "https://fe-project.zooniverse.org";
     location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:classify(?:/.+?)?)?/?$ {
-        resolver 8.8.8.8;
+        resolver 1.1.1.1;
         proxy_pass $fe_project_uri;
         proxy_set_header Host fe-project.zooniverse.org;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -87,6 +87,14 @@ server {
         return 301 /projects/laac-lscp/maturity-of-baby-sounds$1$2$is_args$query_string;
     }
 
+    set $fe_project_uri "https://fe-project.zooniverse.org";
+    location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:classify(?:/.+?)?)?/?$ {
+        resolver 8.8.8.8;
+        proxy_pass $fe_project_uri;
+        proxy_set_header Host fe-project.zooniverse.org;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    }
+
     # ensure the js and CSS assets are served on the same or subdomain
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -1,10 +1,3 @@
-upstream k8s-fe-project {
-  # the service name in k8s (http)
-  server zooniverse-org-project-production;
-  # use the below when external k8s cluster URL (testing) via HTTPS
-  # server fe-project.zooniverse.org;
-}
-
 server {
     set $csp_whitelist "zooniverse.org *.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
@@ -94,7 +87,7 @@ server {
         return 301 /projects/laac-lscp/maturity-of-baby-sounds$1$2$is_args$query_string;
     }
 
-    set $fe_project_uri "http://k8s-fe-project";
+    set $fe_project_uri "https://fe-project.zooniverse.org";
     location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:classify(?:/.+?)?)?/?$ {
         resolver 8.8.8.8;
         proxy_pass $fe_project_uri;

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -92,7 +92,6 @@ server {
         resolver 1.1.1.1;
         proxy_pass $fe_project_uri;
         proxy_set_header Host fe-project.zooniverse.org;
-        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
 
     # ensure the js and CSS assets are served on the same or subdomain


### PR DESCRIPTION
this PR adds the ability to the static proxy to route our project URLs to either the object store (azure blobs) or to the upstream server (fe-project nextJS app).

This technique avoids adding CDN (AFD) routing rules for every new project project we launch on the nextjs apps as they cost money. We don't lose any value in the CDN as the responses are still returned on the CDN domain

------------------------------------
### Current HTTP request routing

#### non-matching fe-project rules
client -> AFD (CDN) -> static proxy (k8s cluster)

#### matching fe-project rules
client -> AFD (CDN) -> fe-project app (k8s cluster)

### This PR HTTP request routing

#### non-matching fe-project rules
client -> AFD (CDN) -> static proxy (k8s cluster) -> object storage (azure blobs)

#### matching fe-project rules
client -> AFD (CDN) -> static proxy (k8s cluster) -> fe-project

------------------------------------
As such the change above adds a network hop to the request routing via our nginx proxy vs the addition of the AFD CDN routing rules.

Routing rules cost money (albeit not much) and come with the complexity of setting them up on Azure (get it wrong and you can break the production www.zooniverse.org site).  

Some benefits of having the configs in nginx is the 
- ability to PR review the changes for new project (via this repo)
- avoid the complexity of knowing how to setup AFD (or even have access) 
- independent of the CDN provider (not tied to azure)

I think this is a reasonable trade off and I'm going to try this for the launch of the gridtool project https://www.zooniverse.org/projects/zookeeper/galaxy-zoo-weird-and-wonderful