### PR TITLE
fix talk archiver site with broken relative path link URLs

### DIFF
--- a/sites/invalid-paths.ouroboros.talk.conf
+++ b/sites/invalid-paths.ouroboros.talk.conf
@@ -16,6 +16,11 @@ server {
                 talk.snapshotserengeti.org
                 talk.wormwatchlab.org;
 
+  # ensure trailing slashes on root level paths
+  location ~* /(boards|recent)$ {
+    # rewrite the URL and search for a new location match (/ one below)
+    rewrite ^([^.]*[^/])$ $1/ last;
+  }
   # for /users/ static pages that end in '.' char
   # '.' chars are illegal in azure so we mapped it to a
   # '_' char path prefix in azure blob store

--- a/sites/invalid-paths.ouroboros.talk.conf
+++ b/sites/invalid-paths.ouroboros.talk.conf
@@ -18,9 +18,16 @@ server {
 
   # ensure trailing slashes on root level paths
   location ~* /(boards|recent)$ {
-    # rewrite the URL and search for a new location match (/ one below)
+    # rewrite the URL and search ('last') for a new location match (/ one below)
     rewrite ^([^.]*[^/])$ $1/ last;
   }
+
+  # ensure trailing slashes on nested paths only 1 level down
+  location ~* ^/(subjects|boards|tags)/[^\/\.]+?[^\/]$ {
+    # rewrite the URL and search ('last') for a new location match (/ one below)
+    rewrite ^([^.]*[^/])$ $1/ last;
+  }
+
   # for /users/ static pages that end in '.' char
   # '.' chars are illegal in azure so we mapped it to a
   # '_' char path prefix in azure blob store

--- a/sites/invalid-paths.ouroboros.talk.conf
+++ b/sites/invalid-paths.ouroboros.talk.conf
@@ -28,12 +28,24 @@ server {
     rewrite ^([^.]*[^/])$ $1/ last;
   }
 
-  # for /users/ static pages that end in '.' char
+  # for '/users/username' static pages that do not end in '.' char but without a trailing slash
+  # ensure we redirect users name paths to have the trailing '/' chat
+  location ~* ^/users/[^\/]+?[^\/]$ {
+    # rewrite the URL and search return a 301 redirect for a new location match
+    # the resulting Location path will be served by another matching rule in this config (most likely the last one)
+    rewrite ^([^.]*[^/])$ $1/ permanent;
+    # rewrite and redirect the 3 possible levels of trailing '.' chars, i checked the data and 3 was the max
+    # match invalid char endings like ... | .. | .
+    rewrite '^(.+?\.{1,3}.*)?$' $1/ permanent;
+  }
+
+
+  # for '/users/username./' static pages that end in an invalid '.' char but with a trailing slash (redirected from above)
+  #   note: is combined with above more specific non-trailing slash redirect above to ensure we have the trailing slash
   # '.' chars are illegal in azure so we mapped it to a
   # '_' char path prefix in azure blob store
   # we will proxy pass to the azure blob mapped '_' file prefix
-  location ~* ^/users/.+?\.+(?:\/.*)?$ {
-
+  location ~* ^/users/.+?\.+\/.*?$ {
     # rewrite the 3 possible levels of trailing '.' chars, i checked the data and 3 was the max
     # stop after each rewrite and try the proxy pass
     # note the URI contains the host and rewritten path this is sent to proxy_pass via nginx

--- a/sites/invalid-paths.ouroboros.talk.conf
+++ b/sites/invalid-paths.ouroboros.talk.conf
@@ -16,16 +16,18 @@ server {
                 talk.snapshotserengeti.org
                 talk.wormwatchlab.org;
 
-  # ensure trailing slashes on root level paths
+  # ensure we redirect to have the trailing slashes on root level paths
   location ~* /(boards|recent)$ {
-    # rewrite the URL and search ('last') for a new location match (/ one below)
-    rewrite ^([^.]*[^/])$ $1/ last;
+    # rewrite the URL and search return a 301 redirect for a new location match
+    # the resulting Location path will be served by another matching rule in this config (most likely the last one)
+    rewrite ^([^.]*[^/])$ $1/ permanent;
   }
 
-  # ensure trailing slashes on nested paths only 1 level down
+  # ensure we redirect to have the trailing slashes on special nested paths but only 1 level down
   location ~* ^/(subjects|boards|tags)/[^\/\.]+?[^\/]$ {
-    # rewrite the URL and search ('last') for a new location match (/ one below)
-    rewrite ^([^.]*[^/])$ $1/ last;
+    # rewrite the URL and search return a 301 redirect for a new location match
+    # the resulting Location path will be served by another matching rule in this config (most likely the last one)
+    rewrite ^([^.]*[^/])$ $1/ permanent;
   }
 
   # for '/users/username' static pages that do not end in '.' char but without a trailing slash

--- a/sites/invalid-paths.ouroboros.talk.conf
+++ b/sites/invalid-paths.ouroboros.talk.conf
@@ -1,19 +1,38 @@
 # Static Ouroboros talk pages migrated from s3 to azure blob store
-# but have invalid file names for azure (ending in .)
 #
-# These files were renamed to have a valid end char '_'
+# this file is used to ensure the migrated ouroboros talk domains work correctly
+# this nginx config addresses the following issues
 #
-# we now redirect any URLs that end in '.' char
-# to the moved files that end in '_'
+# 1. some have invalid file names for azure (ending in .)
+#    These files were renamed to have a valid end char '_'
+#     we now redirect any URLs that end in '.' char
+#     to the moved files that end in '_'
+#
+# 2. Azure handles tailing slashes on URL paths differently from S3 & GCP
+#    see https://github.com/zooniverse/static/issues/238#issuecomment-880915033 for details
+#    We need to redirect any paths that serve index.html pages to ensure the relative URLs in the page
+#    work correctly in the browsers i.e. match the was S3 used to work.
+
 server {
     include /etc/nginx/ssl.default.conf;
-    # all domains that had invalid file names
+    # all ouorboros talk domains
     server_name radiotalk.galaxyzoo.org
+                talk.asteroidzoo.org
                 talk.chicagowildlifewatch.org
+                talk.chimpandsee.org
+                talk.condorwatch.org
                 talk.diskdetective.org
                 talk.galaxyzoo.org
+                talk.higgshunters.org
+                talk.milkywayproject.org
+                talk.operationwardiary.org
+                talk.penguinwatch.org
+                talk.planetfour.org
                 talk.planethunters.org
+                talk.planktonportal.org
+                talk.sciencegossip.org
                 talk.snapshotserengeti.org
+                talk.spacewarps.org
                 talk.wormwatchlab.org;
 
   # ensure we redirect to have the trailing slashes on root level paths


### PR DESCRIPTION
closes #238 

This PR fixes the way our old talk archiver sites work in azure by mimicing what s3 used to do, specifically it 
1. redirects any missing trailing slash paths that would previously serve an index.html page
    + e.g. `users/Arne_D.` now redirects to `users/Arne_D./`
2. adds the explicit list of all talk archiver site domains to fix all broken links on all talk archiver site pages. 