### PR TITLE
Port Front Door FEM redirects, include /about page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN mkdir -p /nginx-cache/  &&  touch /etc/nginx-deny.conf
 ADD nginx.conf /etc/nginx/nginx.conf
 ADD nginx-redirects.conf /etc/nginx/redirects.conf
 ADD nginx-proxy.conf /etc/nginx/proxy.conf
+ADD nginx-fem-redirects.conf /etc/nginx/fem-redirects.conf
 ADD nginx-s3-proxy-headers.conf /etc/nginx/s3-proxy-headers.conf
 ADD nginx-az-proxy-headers.conf /etc/nginx/az-proxy-headers.conf
 ADD sites/ /etc/nginx/sites/

--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -1,0 +1,48 @@
+set $fe_project_uri "https://fe-project.zooniverse.org";
+location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.zooniverse.org;
+}
+
+location ~* ^/projects/hughdickinson/superwasp-black-hole-hunters/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.zooniverse.org;
+}
+
+location ~* ^/projects/bogden/scarlets-and-blues/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.zooniverse.org;
+}
+
+location ~* ^/projects/adamamiller/zwickys-stellar-sleuths/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.zooniverse.org;
+}
+
+location ~* ^/projects/humphrydavy/davy-notebooks-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.zooniverse.org;
+}
+
+location ~* ^/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.zooniverse.org;
+}
+
+location ~* ^/projects/msalmon/hms-nhs-the-nautical-health-service/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.zooniverse.org;
+}
+
+location ~* ^/projects/nora-dot-eisner/planet-hunters-tess/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.zooniverse.org;
+}

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -1,6 +1,7 @@
 server {
     set $csp_whitelist "zooniverse.org *.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
+    include /etc/nginx/fem-redirects.conf;
     server_name www.zooniverse.org;
 
     rewrite ^/lab-policies$ https://help.zooniverse.org/getting-started/lab-policies permanent;
@@ -89,25 +90,6 @@ server {
 
     location ~* ^/projects/chiarasemenzin/maturity-of-baby-sounds(/?)(.*?)\/?$ {
         return 301 /projects/laac-lscp/maturity-of-baby-sounds$1$2$is_args$query_string;
-    }
-
-    set $fe_project_uri "https://fe-project.zooniverse.org";
-    location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:classify(?:/.+?)?)?/?$ {
-        resolver 1.1.1.1;
-        proxy_pass $fe_project_uri;
-        proxy_set_header Host fe-project.zooniverse.org;
-    }
-
-    location ~* ^/projects/hughdickinson/superwasp-black-hole-hunters/?(?:classify(?:/.+?)?)?/?$ {
-        resolver 1.1.1.1;
-        proxy_pass $fe_project_uri;
-        proxy_set_header Host fe-project.zooniverse.org;
-    }
-
-    location ~* ^/projects/bogden/scarlets-and-blues/?(?:classify(?:/.+?)?)?/?$ {
-        resolver 1.1.1.1;
-        proxy_pass $fe_project_uri;
-        proxy_set_header Host fe-project.zooniverse.org;
     }
 
     # ensure the js and CSS assets are served on the same or subdomain


### PR DESCRIPTION
Move AFD FEM redirects to new nginx conf file that is included in the main zooniverse.org.conf. Includes the three previous that were added here first. The new behavior is that all requests to `/about` should also be included. I just grouped `(classify|about)` in the existing regex for brevity, but I'd rather not make those matchers any more complicated moving forward.

I tested the matchers with a regex tester and the nginx behavior by curling against the local docker container. I got 200s on requests I expect to hit FEM and 308s on requests that I expected to redirect to FEM. 

These can exist in both places temporarily (requests hit AFD first) and can be removed from AFD and the expected behavior confirmed first before removing all of them. The http-frontend *will deploy when this PR merges*, so this should be reviewed carefully before merging.