### PR TITLE
Add PH NGTS Redirect

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -101,6 +101,12 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
+    server_name ngts.planethunters.org;
+    return 301 https://www.zooniverse.org/projects/mschwamb/planet-hunters-ngts;
+}
+
+server {
+    include /etc/nginx/ssl.default.conf;
     server_name galaxyzoo.org beta.galaxyzoo.org www.hubble.galaxyzoo.org;
     return 301 http://www.galaxyzoo.org$request_uri;
 }


### PR DESCRIPTION
A new Planet Hunters project, PH NGTS, is in development. The project team has requested that a redirect be set up:
Input = https://ngts.planethunters.org/
Output = https://www.zooniverse.org/projects/mschwamb/planet-hunters-ngts

The project's target launch date is Oct 19; this redirect is ready to be enabled at anytime, and anytime in the next week or two weeks would be great.

I've added a redirect server block here, but don't have full confidence that a) this is totally correct, or b) that this is the only action that needs to be taken to enable the redirect.