### PR TITLE
Update ancientlives.org ingress

### DIFF
--- a/kubernetes/ingress/ancientlives.org.yaml
+++ b/kubernetes/ingress/ancientlives.org.yaml
@@ -44,7 +44,7 @@ spec:
     http:
       paths:
       - pathType: Prefix
-        path: /(.*)
+        path: /
         backend:
           service:
             name: http-frontend


### PR DESCRIPTION
Updates the first ingress in the list, which happens to also be a retirement site so we can use it as a test. This ingress gets updated to the stable v1 and the correct schema. It also keeps the wildcard domain handler, which seems to be only used for blog.ancientlives.org. 

Once that's confirmed working, I'd like to figure out if wildcard subdomain matchers are actually any more costly than more simple ones. It makes sense to keep them for TLS purposes just in case if they're not.