### PR TITLE
Remove rewrite target from ancientlives.org ingress

### DIFF
--- a/kubernetes/ingress/ancientlives.org.yaml
+++ b/kubernetes/ingress/ancientlives.org.yaml
@@ -20,7 +20,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:


### PR DESCRIPTION
The schema's right, the paths are right, but the unnecessary rewrite target causes anything below / to redirect. 