### PR TITLE
Serve data.galaxyzoo.org from AWS

### DIFF
--- a/sites/www.galaxyzoo.org.conf
+++ b/sites/www.galaxyzoo.org.conf
@@ -17,3 +17,14 @@ server {
         return 301 https://www.zooniverse.org/projects/zookeeper/galaxy-zoo/;
     }
 }
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name data.galaxyzoo.org;
+
+    location / {
+        resolver 8.8.8.8;
+        proxy_pass             https://zooniverse-static.s3.amazonaws.com/data.galaxyzoo.org/$request_uri;
+        include /etc/nginx/az-proxy-headers.conf;
+    }
+}


### PR DESCRIPTION
This site is served by the static.zooniverse.org fallback, which now points at Azure. The app is old, though, and uses publisssh to deploy via node 9 (😬) to AWS. This conf update is quicker than replacing publisssh with a Github Action, and that's probably fine since this gets a few commits a year.

I'll create an issue on that repo (https://github.com/zooniverse/data.galaxyzoo.org/) in case we delete everything off of S3 someday.