### PR TITLE
Add rules for production and staging NextJS apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ADD nginx.conf /etc/nginx/nginx.conf
 ADD nginx-redirects.conf /etc/nginx/redirects.conf
 ADD nginx-proxy.conf /etc/nginx/proxy.conf
 ADD nginx-fem-redirects.conf /etc/nginx/fem-redirects.conf
+ADD nginx-fem-staging-redirects.conf /etc/nginx/fem-staging-redirects.conf
 ADD nginx-s3-proxy-headers.conf /etc/nginx/s3-proxy-headers.conf
 ADD nginx-az-proxy-headers.conf /etc/nginx/az-proxy-headers.conf
 ADD sites/ /etc/nginx/sites/

--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -1,18 +1,28 @@
 set $fe_project_uri "https://fe-project.zooniverse.org";
 set $fe_content_pages_uri "https://fe-content-pages.zooniverse.org";
 
+# Project app data and static files
 location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host fe-project.zooniverse.org;
 }
 
+# About pages data and static files
 location ~* ^/about/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
     proxy_set_header Host fe-content-pages.zooniverse.org;
 }
 
+# Zooniverse About pages
+location ~* ^/about/(?:team|publications)/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_content_pages_uri;
+    proxy_set_header Host fe-content-pages.zooniverse.org;
+}
+
+# FEM projects
 location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;

--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -1,4 +1,17 @@
 set $fe_project_uri "https://fe-project.zooniverse.org";
+
+location ~* ^/projects/(?:_next|assets)/.+?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.zooniverse.org;
+}
+
+location ~* ^/about/(?:_next|assets)/.+?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-content-pages.zooniverse.org;
+}
+
 location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;

--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -1,4 +1,5 @@
 set $fe_project_uri "https://fe-project.zooniverse.org";
+set $fe_content_pages_uri "https://fe-content-pages.zooniverse.org";
 
 location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
@@ -8,7 +9,7 @@ location ~* ^/projects/(?:_next|assets)/.+?$ {
 
 location ~* ^/about/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
-    proxy_pass $fe_project_uri;
+    proxy_pass $fe_content_pages_uri;
     proxy_set_header Host fe-content-pages.zooniverse.org;
 }
 

--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -1,102 +1,104 @@
 set $fe_project_uri "https://fe-project.zooniverse.org";
 set $fe_content_pages_uri "https://fe-content-pages.zooniverse.org";
+set $fe_project_host "fe-project.zooniverse.org";
+set $fe_content_pages_host "fe-content-pages.zooniverse.org";
 
 # Project app data and static files
 location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 # About pages data and static files
 location ~* ^/about/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host fe-content-pages.zooniverse.org;
+    proxy_set_header Host $fe_content_pages_host;
 }
 
 # Zooniverse About pages
 location ~* ^/about/(?:team|publications)/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host fe-content-pages.zooniverse.org;
+    proxy_set_header Host $fe_content_pages_host;
 }
 
 # FEM projects
 location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/hughdickinson/superwasp-black-hole-hunters/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/bogden/scarlets-and-blues/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/kmc35/peoples-contest-digital-archive/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/adamamiller/zwickys-stellar-sleuths/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/humphrydavy/davy-notebooks-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/msalmon/hms-nhs-the-nautical-health-service/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/nora-dot-eisner/planet-hunters-tess/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/rachaelsking/corresponding-with-quakers/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/mariaedgeworthletters/maria-edgeworth-letters/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/pmlogan/poets-and-lovers/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 location ~* ^/projects/blicksam/transcription-task-testing/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -3,8 +3,8 @@ set $fe_content_pages_uri "https://fe-content-pages.preview.zooniverse.org";
 set $fe_project_host "fe-project.preview.zooniverse.org";
 set $fe_content_pages_host "fe-content-pages.preview.zooniverse.org";
 
-# FEM projects app
-location ~* ^/projects/.*$ {
+# Project app data and static files
+location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -22,4 +22,18 @@ location ~* ^/about/(?:team|publications)/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
     proxy_set_header Host $fe_content_pages_host;
+}
+
+# FEM Projects app routes for project index page (optional trailing slash)
+location ~* ^/projects/[\w-]*?/[\w-]+?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host $fe_project_host;
+}
+
+# FEM projects app: home,about and classify pages
+location ~* ^/projects/[\w-]*/[\w-]+/(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host $fe_project_host;
 }

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -1,0 +1,23 @@
+set $fe_project_uri "https://fe-project.preview.zooniverse.org";
+set $fe_content_pages_uri "https://fe-content-pages.preview.zooniverse.org";
+
+# FEM projects app
+location ~* ^/projects/.*$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host fe-project.preview.zooniverse.org;
+}
+
+# About pages data and static files
+location ~* ^/about/(?:_next|assets)/.+?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_content_pages_uri;
+    proxy_set_header Host fe-content-pages.preview.zooniverse.org;
+}
+
+# Zooniverse About pages
+location ~* ^/about/(?:team|publications)/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_content_pages_uri;
+    proxy_set_header Host fe-content-pages.preview.zooniverse.org;
+}

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -1,23 +1,25 @@
 set $fe_project_uri "https://fe-project.preview.zooniverse.org";
 set $fe_content_pages_uri "https://fe-content-pages.preview.zooniverse.org";
+set $fe_project_host "fe-project.preview.zooniverse.org";
+set $fe_content_pages_host "fe-content-pages.preview.zooniverse.org";
 
 # FEM projects app
 location ~* ^/projects/.*$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
-    proxy_set_header Host fe-project.preview.zooniverse.org;
+    proxy_set_header Host $fe_project_host;
 }
 
 # About pages data and static files
 location ~* ^/about/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host fe-content-pages.preview.zooniverse.org;
+    proxy_set_header Host $fe_content_pages_host;
 }
 
 # Zooniverse About pages
 location ~* ^/about/(?:team|publications)/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host fe-content-pages.preview.zooniverse.org;
+    proxy_set_header Host $fe_content_pages_host;
 }

--- a/sites/frontend.preview.zooniverse.org.conf
+++ b/sites/frontend.preview.zooniverse.org.conf
@@ -1,5 +1,6 @@
 server {
     set $csp_whitelist "zooniverse.org *.zooniverse.org";
+    set $proxy_path "www.zooniverse.org/";
     include /etc/nginx/ssl.default.conf;
     include /etc/nginx/fem-staging-redirects.conf;
     server_name frontend.preview.zooniverse.org;
@@ -95,7 +96,7 @@ server {
     # ensure the js and CSS assets are served on the same or subdomain
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;
-        proxy_pass  https://zooniversestatic.z13.web.core.windows.net/www.zooniverse.org$request_uri;
+        proxy_pass  https://zooniversestatic.z13.web.core.windows.net/$proxy_path$request_uri;
         include /etc/nginx/az-proxy-headers.conf;
     }
 
@@ -124,7 +125,7 @@ server {
         rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.zooniverse.org$request_uri;
 
         resolver 8.8.8.8;
-        proxy_pass https://zooniversestatic.z13.web.core.windows.net/www.zooniverse.org/;
+        proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path;
 
         include /etc/nginx/az-proxy-headers.conf;
     }

--- a/sites/frontend.preview.zooniverse.org.conf
+++ b/sites/frontend.preview.zooniverse.org.conf
@@ -95,7 +95,7 @@ server {
 
     # ensure the js and CSS assets are served on the same or subdomain
     location ~ \.(js|css)$ {
-        resolver 8.8.8.8;
+        resolver 1.1.1.1;
         proxy_pass  https://zooniversestatic.z13.web.core.windows.net/$proxy_path$request_uri;
         include /etc/nginx/az-proxy-headers.conf;
     }
@@ -106,7 +106,7 @@ server {
     location /unsubscribe {
         rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.zooniverse.org$request_uri;
 
-        resolver 8.8.8.8;
+        resolver 1.1.1.1;
         if ($request_method ~ ^(GET|HEAD)$) {
             proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host/;
             set $proxy_host_header "zooniversestatic.z13.web.core.windows.net";
@@ -124,7 +124,7 @@ server {
     location / {
         rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.zooniverse.org$request_uri;
 
-        resolver 8.8.8.8;
+        resolver 1.1.1.1;
         proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path;
 
         include /etc/nginx/az-proxy-headers.conf;

--- a/sites/frontend.preview.zooniverse.org.conf
+++ b/sites/frontend.preview.zooniverse.org.conf
@@ -1,0 +1,131 @@
+server {
+    set $csp_whitelist "zooniverse.org *.zooniverse.org";
+    include /etc/nginx/ssl.default.conf;
+    include /etc/nginx/fem-staging-redirects.conf;
+    server_name frontend.preview.zooniverse.org;
+
+    rewrite ^/lab-policies$ https://help.zooniverse.org/getting-started/lab-policies permanent;
+    rewrite ^/glossary$ https://help.zooniverse.org/getting-started/glossary permanent;
+
+    rewrite ^/help$ https://help.zooniverse.org/getting-started permanent;
+    rewrite ^/help/best-practices$ https://help.zooniverse.org/best-practices permanent;
+    rewrite ^/help/glossary$ https://help.zooniverse.org/getting-started/glossary permanent;
+    rewrite ^/help/lab-policies$ https://help.zooniverse.org/getting-started/lab-policies permanent;
+    rewrite ^/help/example$ https://help.zooniverse.org/getting-started/example permanent;
+
+    rewrite ^/lab-best-practices$ https://help.zooniverse.org/best-practices permanent;
+    rewrite ^/lab-best-practices/introduction$ https://help.zooniverse.org/best-practices permanent;
+    rewrite ^/lab-best-practices/great-project$ https://help.zooniverse.org/best-practices/1-great-project permanent;
+    rewrite ^/lab-best-practices/launch-rush$ https://help.zooniverse.org/best-practices/2-launch-rush permanent;
+    rewrite ^/lab-best-practices/the-long-haul$ https://help.zooniverse.org/best-practices/3-long-haul permanent;
+    rewrite ^/lab-best-practices/resources$ https://help.zooniverse.org/best-practices/4-resources permanent;
+
+    location /password/reset {
+        return 301 /reset-password;
+    }
+
+    location /projects/current {
+        return 301 /;
+    }
+
+    location /signup {
+        return 301 /accounts/register;
+    }
+
+    location /publications {
+        return 301 /about/publications;
+    }
+
+    location /api/events {
+        return 301 https://panoptes.zooniverse.org/api/events;
+    }
+
+    location /account/newsletters {
+        return 301 /settings/email;
+    }
+
+    location ~* /project(_|-)?builder$ {
+        return 301 /lab;
+    }
+
+    location /account/settings {
+        return 301 /settings;
+    }
+
+    location /home {
+        return 301 /;
+    }
+
+    location /team {
+        return 301 /about/team;
+    }
+
+    location ~* /project/.* {
+        return 301 /projects;
+    }
+
+    location /education {
+        return 301 /about/education;
+    }
+
+    location /contact {
+        return 301 /about/contact;
+    }
+
+    location ~* ^/projects/meredithspalmer/(cedar-creek-eyes-on-the-wild/?)(.*?)\/?$ {
+        return 301 /projects/forestis/$1$2$is_args$query_string;
+    }
+
+    location ~* ^/projects/karilint/the-cradle-of-mankind(/?)(.*?)\/?$ {
+        return 301 /projects/karilint/cradle-of-humanity$1$2$is_args$query_string;
+    }
+
+    location ~* ^/projects/cseidenstuecker/every-name-counts(/?)(.*?)\/?$ {
+        return 301 /projects/arolsen-archives/every-name-counts$1$2$is_args$query_string;
+    }
+
+    location ~* ^/projects/kevinesolberg/mapping-prejudice(/?)(.*?)\/?$ {
+        return 301 /projects/mappingprejudice/mapping-prejudice$1$2$is_args$query_string;
+    }
+
+    location ~* ^/projects/chiarasemenzin/maturity-of-baby-sounds(/?)(.*?)\/?$ {
+        return 301 /projects/laac-lscp/maturity-of-baby-sounds$1$2$is_args$query_string;
+    }
+
+    # ensure the js and CSS assets are served on the same or subdomain
+    location ~ \.(js|css)$ {
+        resolver 8.8.8.8;
+        proxy_pass  https://zooniversestatic.z13.web.core.windows.net/www.zooniverse.org$request_uri;
+        include /etc/nginx/az-proxy-headers.conf;
+    }
+
+    # unsubscribe route uses redirects between panoptes and the UI code
+    # so needs it's own location block to handle the form submission POST
+    # and the GET page loading (PFE routing handles the path)
+    location /unsubscribe {
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.zooniverse.org$request_uri;
+
+        resolver 8.8.8.8;
+        if ($request_method ~ ^(GET|HEAD)$) {
+            proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host/;
+            set $proxy_host_header "zooniversestatic.z13.web.core.windows.net";
+        }
+        if ($request_method = POST) {
+            proxy_pass             https://panoptes.zooniverse.org$request_uri;
+            set $proxy_host_header "panoptes.zooniverse.org";
+        }
+        proxy_set_header Host $proxy_host_header;
+        proxy_redirect         /$host/ /;
+
+        include /etc/nginx/az-proxy-headers.conf;
+    }
+
+    location / {
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.zooniverse.org$request_uri;
+
+        resolver 8.8.8.8;
+        proxy_pass https://zooniversestatic.z13.web.core.windows.net/www.zooniverse.org/;
+
+        include /etc/nginx/az-proxy-headers.conf;
+    }
+}


### PR DESCRIPTION
This adds rules for:
## production
- zooniverse.org/projects/_next/* (NextJS projects app data and bundles.)
- zooniverse.org/projects/assets/* (Projects app images.)
- zooniverse.org/about/_next/* (NextJS content pages app data and bundles.)
- zooniverse.org/about/assets/* (Content page images.)
- zooniverse.org/about/team (Zoo team page.)
- zooniverse.org/about/publications (Zoo publications page.)

## staging
- frontend.preview.zooniverse.org/projects/:owner:/:project:/(about|classify) (Stage all projects with NextJS.)
- frontend.preview.zooniverse.org/about/_next/* (NextJS content pages app data and bundles.)
- frontend.preview.zooniverse.org/about/assets/* (Content page images.)
- frontend.preview.zooniverse.org/about/team (Zoo team page.)
- frontend.preview.zooniverse.org/about/publications (Zoo publications page.)

Closes #251.
Towards https://github.com/zooniverse/front-end-monorepo/issues/2518