### PR TITLE
avoid extra trailing slashes in proxy and rewrite paths

### DIFF
--- a/sites/frontend.preview.zooniverse.org.conf
+++ b/sites/frontend.preview.zooniverse.org.conf
@@ -1,6 +1,6 @@
 server {
     set $csp_whitelist "zooniverse.org *.zooniverse.org";
-    set $proxy_path "www.zooniverse.org/";
+    set $proxy_path "www.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
     include /etc/nginx/fem-staging-redirects.conf;
     server_name frontend.preview.zooniverse.org;
@@ -104,11 +104,11 @@ server {
     # so needs it's own location block to handle the form submission POST
     # and the GET page loading (PFE routing handles the path)
     location /unsubscribe {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.zooniverse.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
         resolver 1.1.1.1;
         if ($request_method ~ ^(GET|HEAD)$) {
-            proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host/;
+            proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
             set $proxy_host_header "zooniversestatic.z13.web.core.windows.net";
         }
         if ($request_method = POST) {
@@ -122,10 +122,10 @@ server {
     }
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/www.zooniverse.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
         resolver 1.1.1.1;
-        proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path;
+        proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
 
         include /etc/nginx/az-proxy-headers.conf;
     }


### PR DESCRIPTION
linked to #253 - This PR ensures we create the proxy paths and rewrite URLs without extra trailing slashes.

paths that use $request_uri add the trailing slash by default

When combined with the var $proxy_path with a trailing slash we end with proxy paths that look like 
`/www.zooniverse.org//vendor-9c07d40d15bc35fef5e3.css` and these 404 at the blob store. 

After this PR this proxy path will be `/www.zooniverse.org/vendor-9c07d40d15bc35fef5e3.css`

