### PR TITLE
Fem app proxy security headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN mkdir -p /nginx-cache/  &&  touch /etc/nginx-deny.conf
 ADD nginx.conf /etc/nginx/nginx.conf
 ADD nginx-redirects.conf /etc/nginx/redirects.conf
 ADD nginx-proxy.conf /etc/nginx/proxy.conf
+ADD nginx-proxy-security-headers.conf /etc/nginx/proxy-security-headers.conf
 ADD nginx-fem-redirects.conf /etc/nginx/fem-redirects.conf
 ADD nginx-fem-staging-redirects.conf /etc/nginx/fem-staging-redirects.conf
 ADD nginx-s3-proxy-headers.conf /etc/nginx/s3-proxy-headers.conf

--- a/nginx-az-proxy-headers.conf
+++ b/nginx-az-proxy-headers.conf
@@ -1,7 +1,4 @@
-add_header 'X-Content-Type-Options' 'nosniff';
-add_header 'Content-Security-Policy' "frame-ancestors 'self'";
-add_header 'X-Content-Security-Policy' "frame-ancestors 'self'";
-add_header 'X-XSS-Protection' '1; mode=block';
+include /etc/nginx/proxy-security-headers.conf;
 
 proxy_ssl_server_name on;
 proxy_http_version 1.1;

--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -8,6 +8,8 @@ location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 # About pages data and static files
@@ -15,6 +17,8 @@ location ~* ^/about/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
     proxy_set_header Host $fe_content_pages_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 # Zooniverse About pages
@@ -22,6 +26,8 @@ location ~* ^/about/(?:team|publications)/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
     proxy_set_header Host $fe_content_pages_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 # FEM projects
@@ -29,82 +35,110 @@ location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|ab
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/hughdickinson/superwasp-black-hole-hunters/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/bogden/scarlets-and-blues/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/kmc35/peoples-contest-digital-archive/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/adamamiller/zwickys-stellar-sleuths/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/humphrydavy/davy-notebooks-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/msalmon/hms-nhs-the-nautical-health-service/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/nora-dot-eisner/planet-hunters-tess/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/rachaelsking/corresponding-with-quakers/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/mariaedgeworthletters/maria-edgeworth-letters/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/pmlogan/poets-and-lovers/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-african-violet-family/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host fe-project.zooniverse.org;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 location ~* ^/projects/blicksam/transcription-task-testing/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -8,6 +8,8 @@ location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 # About pages data and static files
@@ -15,6 +17,8 @@ location ~* ^/about/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
     proxy_set_header Host $fe_content_pages_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 # Zooniverse About pages
@@ -22,6 +26,8 @@ location ~* ^/about/(?:team|publications)/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
     proxy_set_header Host $fe_content_pages_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 # FEM Projects app routes for project index page (optional trailing slash)
@@ -29,6 +35,8 @@ location ~* ^/projects/[\w-]*?/[\w-]+?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }
 
 # FEM projects app: home,about and classify pages
@@ -36,4 +44,6 @@ location ~* ^/projects/[\w-]*/[\w-]+/(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
 }

--- a/nginx-proxy-security-headers.conf
+++ b/nginx-proxy-security-headers.conf
@@ -1,0 +1,4 @@
+add_header 'X-Content-Type-Options' 'nosniff';
+add_header 'Content-Security-Policy' "frame-ancestors 'self'";
+add_header 'X-Content-Security-Policy' "frame-ancestors 'self'";
+add_header 'X-XSS-Protection' '1; mode=block';

--- a/nginx-s3-proxy-headers.conf
+++ b/nginx-s3-proxy-headers.conf
@@ -3,8 +3,8 @@ add_header 'Access-Control-Allow-Credentials' 'true';
 add_header 'Access-Control-Allow-Methods' 'GET';
 add_header 'Access-Control-Allow-Headers' 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
 add_header 'X-Content-Type-Options' 'nosniff';
-add_header 'Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
-add_header 'X-Content-Security-Policy' "frame-ancestors 'self' $csp_whitelist";
+add_header 'Content-Security-Policy' "frame-ancestors 'self'";
+add_header 'X-Content-Security-Policy' "frame-ancestors 'self'";
 add_header 'X-XSS-Protection' '1; mode=block';
 
 proxy_set_header       Host zooniverse-static.s3-website-us-east-1.amazonaws.com;

--- a/sites/frontend.preview.zooniverse.org.conf
+++ b/sites/frontend.preview.zooniverse.org.conf
@@ -1,5 +1,4 @@
 server {
-    set $csp_whitelist "zooniverse.org *.zooniverse.org";
     set $proxy_path "www.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
     include /etc/nginx/fem-staging-redirects.conf;

--- a/sites/star.pfe-preview.zooniverse.org.conf
+++ b/sites/star.pfe-preview.zooniverse.org.conf
@@ -1,5 +1,4 @@
 server {
-    set $csp_whitelist "zooniverse.org *.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
     server_name "~^(?P<subdomain>.*)\.pfe-preview\.zooniverse\.org$";
 

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -1,5 +1,4 @@
 server {
-    set $csp_whitelist "zooniverse.org *.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
     include /etc/nginx/fem-redirects.conf;
     server_name www.zooniverse.org;


### PR DESCRIPTION
Ensure we add the security response headers when proxying responses to our FEM apps.
Before this PR change
```
$ curl -I -H "Host: frontend.preview.zooniverse.org" http://localhost:8080/projects/zookeeper/galaxy-zoo
HTTP/1.1 200 OK
Server: nginx/1.19.6
Date: Tue, 16 Nov 2021 16:00:00 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 138274
Connection: keep-alive
Vary: Accept-Encoding
X-Powered-By: Next.js
Cache-Control: max-age=60
ETag: "21c22-kp1AcNANv397EXue49neLy+rYMU"
Vary: Accept-Encoding
Strict-Transport-Security: max-age=15724800; includeSubDomains
```

After this PR change
```
$ curl -I -H "Host: frontend.preview.zooniverse.org" http://localhost:8080/projects/zookeeper/galaxy-zoo
HTTP/1.1 200 OK
Server: nginx/1.19.6
Date: Tue, 16 Nov 2021 16:02:12 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 138274
Connection: keep-alive
Vary: Accept-Encoding
X-Powered-By: Next.js
Cache-Control: max-age=60
ETag: "21c22-kp1AcNANv397EXue49neLy+rYMU"
Vary: Accept-Encoding
Strict-Transport-Security: max-age=15724800; includeSubDomains
X-Content-Type-Options: nosniff
Content-Security-Policy: frame-ancestors 'self'
X-Content-Security-Policy: frame-ancestors 'self'
X-XSS-Protection: 1; mode=block
```