### PR TITLE
Update SpaceWarps Redirect

### DIFF
--- a/sites/spacewarps.org.conf
+++ b/sites/spacewarps.org.conf
@@ -7,7 +7,7 @@ server {
     }
 
     location / {
-        return 301 https://www.zooniverse.org/projects/aprajita/space-warps-hsc;
+        return 301 https://www.zooniverse.org/projects/aprajita/space-warps-des;
     }
 }
 


### PR DESCRIPTION
DO NOT MERGE -- wait until Monday, Jan 17 to merge (aligned with beta test on Jan 18).

This updates the redirect for spacewarps.org from the older HSC project to the latest DES project.