### PR TITLE
update underlying docker image to stable nginx 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zooniverse/nginx
+FROM zooniverse/nginx:1.20
 
 RUN mkdir -p /nginx-cache/  &&  touch /etc/nginx-deny.conf
 


### PR DESCRIPTION
This PR updates the underlying nginx version to stable 1.20 (no patch so we get the increments on rebuild). 

Linked to https://github.com/zooniverse/docker-nginx/pull/3