### PR TITLE
Add FEM proxy rule for PRINT project

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -135,6 +135,14 @@ location ~* ^/projects/emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-af
     include /etc/nginx/proxy-security-headers.conf;
 }
 
+location ~* ^/projects/printmigrationnetwork/print/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
 location ~* ^/projects/blicksam/transcription-task-testing/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;


### PR DESCRIPTION
Add the PRINT project to `fem-redirects`.