### PR TITLE
Add mapping-viz-staging host to zooniverse.org ingress

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -235,7 +235,7 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: tove-production-app
+          serviceName: mapping-viz-tools-staging
           servicePort: 80
         path: /(.*)
 

--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -230,6 +230,15 @@ spec:
           serviceName: http-frontend
           servicePort: 80
         path: /(.*)
+
+  - host: mapping-viz-staging.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: tove-production-app
+          servicePort: 80
+        path: /(.*)
+
   - host: notifications-staging.zooniverse.org
     http:
       paths:


### PR DESCRIPTION
Already added the subdomain to DNS Zones.

See https://github.com/zooniverse/mapping-viz-tools/issues/55