### PR TITLE
add zoo-notes.preview server block

### DIFF
--- a/sites/zoo-notes.preview.zooniverse.org.conf
+++ b/sites/zoo-notes.preview.zooniverse.org.conf
@@ -1,0 +1,15 @@
+server {
+  include /etc/nginx/ssl.default.conf;
+  server_name zoo-notes.preview.zooniverse.org;
+
+  location / {
+      resolver 1.1.1.1;
+
+      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/zoo-notes.preview.zooniverse.org$request_uri;
+
+      # This is a hack to get nginx to discard the uri in the proxy request
+      set $uri_path "zoo-notes.preview.zooniverse.org/";
+      proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$uri_path;
+      include /etc/nginx/az-proxy-headers.conf;
+  }
+}


### PR DESCRIPTION
This PR ensures we served the SPA index.html page for https://zoo-notes.preview.zooniverse.org and ignore html path directives that may not exist as files on the blob storage system. 

This will make the SPA client router work via the URL paths post loading from index.html / JS code. 
