### PR TITLE
add zoo-notes.preview server block again

### DIFF
--- a/sites/zoo-notes.preview.zooniverse.org.conf
+++ b/sites/zoo-notes.preview.zooniverse.org.conf
@@ -1,0 +1,14 @@
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name zoo-notes.preview.zooniverse.org;
+
+    location / {
+      resolver 1.1.1.1;
+      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/zoo-notes$request_uri;
+
+      # This is a hack to get nginx to discard the uri in the proxy request
+      set $uri_path "zoo-notes/";
+      proxy_pass https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/$uri_path;
+      include /etc/nginx/az-proxy-headers.conf;
+    }
+}


### PR DESCRIPTION
linked to #271 - reinstate the zoo-notes.preview.zooniverse.org server block but this time use the preview blob naming prefix to access the correct content