### PR TITLE
Update ingresses G-P

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,8 +66,8 @@ pipeline {
     stage('Dry run deployments') {
       agent any
       steps {
-        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl --context azure apply --dry-run=client --record -f -"
-        sh "kubectl --context azure apply --dry-run=client --record -f kubernetes/ingress/"
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl --context azure apply --dry-run=client -f -"
+        sh "kubectl --context azure apply --dry-run=client -f kubernetes/ingress/"
       }
     }
 
@@ -75,12 +75,12 @@ pipeline {
       when { branch 'master' }
       agent any
       steps {
-        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl --context azure apply --record -f -"
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl --context azure apply -f -"
         sh ""
         sh '''#!/bin/bash
               for ingress in kubernetes/ingress/*
               do
-                kubectl --context azure apply --record -f $ingress
+                kubectl --context azure apply -f $ingress
                 pause=$[($RANDOM % 10 ) + 1]
                 # echo "sleeping a random value of 0.${pause} seconds"
                 sleep .${pause}s

--- a/kubernetes/ingress/galaxyzoo.org.yaml
+++ b/kubernetes/ingress/galaxyzoo.org.yaml
@@ -12,7 +12,7 @@ spec:
   dnsNames:
     - www.galaxyzoo.org
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: www.galaxyzoo.org
@@ -30,10 +30,13 @@ spec:
   - host: www.galaxyzoo.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
+      - pathType: Prefix
         path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -50,14 +53,13 @@ spec:
     - galaxyzoo.org
     - "*.galaxyzoo.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: galaxyzoo.org
   annotations:
     kubernetes.io/ingress.class: nginx
     certmanager.k8s.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -70,14 +72,20 @@ spec:
   - host: galaxyzoo.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.galaxyzoo.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/galaxyzooblog.org.yaml
+++ b/kubernetes/ingress/galaxyzooblog.org.yaml
@@ -13,14 +13,13 @@ spec:
     - galaxyzooblog.org
     - "*.galaxyzooblog.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: galaxyzooblog.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: galaxyzooblog.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.galaxyzooblog.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/galaxyzooforum.org.yaml
+++ b/kubernetes/ingress/galaxyzooforum.org.yaml
@@ -13,14 +13,13 @@ spec:
     - galaxyzooforum.org
     - "*.galaxyzooforum.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: galaxyzooforum.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: galaxyzooforum.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.galaxyzooforum.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/gravityspy.org.yaml
+++ b/kubernetes/ingress/gravityspy.org.yaml
@@ -13,14 +13,13 @@ spec:
     - gravityspy.org
     - "*.gravityspy.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gravityspy.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: gravityspy.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.gravityspy.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/higgshunters.org.yaml
+++ b/kubernetes/ingress/higgshunters.org.yaml
@@ -13,14 +13,13 @@ spec:
     - higgshunters.org
     - "*.higgshunters.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: higgshunters.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: higgshunters.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.higgshunters.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/mappinghistoricskies.org.yaml
+++ b/kubernetes/ingress/mappinghistoricskies.org.yaml
@@ -13,14 +13,13 @@ spec:
     - mappinghistoricskies.org
     - "*.mappinghistoricskies.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mappinghistoricskies.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: mappinghistoricskies.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.mappinghistoricskies.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/measuringtheanzacs.org.yaml
+++ b/kubernetes/ingress/measuringtheanzacs.org.yaml
@@ -13,14 +13,13 @@ spec:
     - measuringtheanzacs.org
     - "*.measuringtheanzacs.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: measuringtheanzacs.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: measuringtheanzacs.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.measuringtheanzacs.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/microplants.org.yaml
+++ b/kubernetes/ingress/microplants.org.yaml
@@ -13,14 +13,13 @@ spec:
     - microplants.org
     - "*.microplants.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: microplants.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: microplants.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.microplants.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/milkywayproject.org.yaml
+++ b/kubernetes/ingress/milkywayproject.org.yaml
@@ -13,14 +13,13 @@ spec:
     - milkywayproject.org
     - "*.milkywayproject.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: milkywayproject.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: milkywayproject.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.milkywayproject.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/moonzoo.org.yaml
+++ b/kubernetes/ingress/moonzoo.org.yaml
@@ -13,14 +13,13 @@ spec:
     - moonzoo.org
     - "*.moonzoo.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: moonzoo.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: moonzoo.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.moonzoo.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/muonhunter.org.yaml
+++ b/kubernetes/ingress/muonhunter.org.yaml
@@ -13,14 +13,13 @@ spec:
     - muonhunter.org
     - "*.muonhunter.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: muonhunter.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: muonhunter.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.muonhunter.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/muonhunters.org.yaml
+++ b/kubernetes/ingress/muonhunters.org.yaml
@@ -13,14 +13,13 @@ spec:
     - muonhunters.org
     - "*.muonhunters.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: muonhunters.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: muonhunters.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.muonhunters.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/nameexoworlds.org.yaml
+++ b/kubernetes/ingress/nameexoworlds.org.yaml
@@ -13,14 +13,13 @@ spec:
     - nameexoworlds.org
     - "*.nameexoworlds.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nameexoworlds.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: nameexoworlds.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.nameexoworlds.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/notesfromnature.org.yaml
+++ b/kubernetes/ingress/notesfromnature.org.yaml
@@ -13,14 +13,13 @@ spec:
     - notesfromnature.org
     - "*.notesfromnature.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: notesfromnature.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: notesfromnature.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.notesfromnature.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/oldweather.org.yaml
+++ b/kubernetes/ingress/oldweather.org.yaml
@@ -13,14 +13,13 @@ spec:
     - oldweather.org
     - "*.oldweather.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: oldweather.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: oldweather.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.oldweather.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/operationwardiary.org.yaml
+++ b/kubernetes/ingress/operationwardiary.org.yaml
@@ -13,14 +13,13 @@ spec:
     - operationwardiary.org
     - "*.operationwardiary.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: operationwardiary-org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: operationwardiary.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.operationwardiary.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/orchidobservers.org.yaml
+++ b/kubernetes/ingress/orchidobservers.org.yaml
@@ -13,14 +13,13 @@ spec:
     - orchidobservers.org
     - "*.orchidobservers.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: orchidobservers.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: orchidobservers.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.orchidobservers.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/penguinwatch.org.yaml
+++ b/kubernetes/ingress/penguinwatch.org.yaml
@@ -11,14 +11,13 @@ spec:
     - www.penguinwatch.org
     - talk.penguinwatch.org
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: penguinwatch.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -31,14 +30,20 @@ spec:
   - host: www.penguinwatch.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: talk.penguinwatch.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/planet4.org.yaml
+++ b/kubernetes/ingress/planet4.org.yaml
@@ -13,14 +13,13 @@ spec:
     - planet4.org
     - "*.planet4.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: planet4.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: planet4.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.planet4.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/planet9search.org.yaml
+++ b/kubernetes/ingress/planet9search.org.yaml
@@ -13,14 +13,13 @@ spec:
     - planet9search.org
     - "*.planet9search.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: planet9search.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: planet9search.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.planet9search.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/planetaryresponsenetwork.com.yaml
+++ b/kubernetes/ingress/planetaryresponsenetwork.com.yaml
@@ -13,14 +13,13 @@ spec:
     - planetaryresponsenetwork.com
     - "*.planetaryresponsenetwork.com"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: planetaryresponsenetwork.com
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: planetaryresponsenetwork.com
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.planetaryresponsenetwork.com"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/planetaryresponsenetwork.net.yaml
+++ b/kubernetes/ingress/planetaryresponsenetwork.net.yaml
@@ -13,14 +13,13 @@ spec:
     - planetaryresponsenetwork.net
     - "*.planetaryresponsenetwork.net"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: planetaryresponsenetwork.net
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: planetaryresponsenetwork.net
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.planetaryresponsenetwork.net"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/planetaryresponsenetwork.org.yaml
+++ b/kubernetes/ingress/planetaryresponsenetwork.org.yaml
@@ -13,14 +13,13 @@ spec:
     - planetaryresponsenetwork.org
     - "*.planetaryresponsenetwork.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: planetaryresponsenetwork.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: planetaryresponsenetwork.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.planetaryresponsenetwork.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/planetfour.org.yaml
+++ b/kubernetes/ingress/planetfour.org.yaml
@@ -13,14 +13,13 @@ spec:
     - planetfour.org
     - "*.planetfour.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: planetfour-org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: planetfour.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.planetfour.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/planethunters.org.yaml
+++ b/kubernetes/ingress/planethunters.org.yaml
@@ -13,14 +13,13 @@ spec:
     - planethunters.org
     - "*.planethunters.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: planethunters.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: planethunters.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.planethunters.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/planetninesearch.org.yaml
+++ b/kubernetes/ingress/planetninesearch.org.yaml
@@ -13,14 +13,13 @@ spec:
     - planetninesearch.org
     - "*.planetninesearch.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: planetninesearch.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: planetninesearch.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.planetninesearch.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/planktonportal.org.yaml
+++ b/kubernetes/ingress/planktonportal.org.yaml
@@ -13,14 +13,13 @@ spec:
     - planktonportal.org
     - "*.planktonportal.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: planktonportal-org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: planktonportal.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.planktonportal.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/pulsarhunter.com.yaml
+++ b/kubernetes/ingress/pulsarhunter.com.yaml
@@ -13,14 +13,13 @@ spec:
     - pulsarhunter.com
     - "*.pulsarhunter.com"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: pulsarhunter.com
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: pulsarhunter.com
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.pulsarhunter.com"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/pulsarhunter.org.yaml
+++ b/kubernetes/ingress/pulsarhunter.org.yaml
@@ -13,14 +13,13 @@ spec:
     - pulsarhunter.org
     - "*.pulsarhunter.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: pulsarhunter.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: pulsarhunter.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.pulsarhunter.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/pulsarhunters.com.yaml
+++ b/kubernetes/ingress/pulsarhunters.com.yaml
@@ -13,14 +13,13 @@ spec:
     - pulsarhunters.com
     - "*.pulsarhunters.com"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: pulsarhunters.com
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: pulsarhunters.com
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.pulsarhunters.com"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80

--- a/kubernetes/ingress/pulsarhunters.org.yaml
+++ b/kubernetes/ingress/pulsarhunters.org.yaml
@@ -13,14 +13,13 @@ spec:
     - pulsarhunters.org
     - "*.pulsarhunters.org"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: pulsarhunters.org
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
@@ -33,14 +32,20 @@ spec:
   - host: pulsarhunters.org
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80
   - host: "*.pulsarhunters.org"
     http:
       paths:
-      - backend:
-          serviceName: http-frontend
-          servicePort: 80
-        path: /(.*)
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: http-frontend
+            port:
+              number: 80


### PR DESCRIPTION
Updates ingresses to use the newer syntax. The middle third, or thereabout. 

Also removes the deprecated `--record` flag from `kubectl apply`s.