### PR TITLE
Add optional locale to FEM project paths

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -79,7 +79,7 @@ location ~* ^/projects/(?:[\w-]*?/)?humphrydavy/davy-notebooks-project/?(?:(clas
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/mainehistory/(?:[\w-]*?/)?beyond-borders-transcribing-historic-maine-land-documents/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mainehistory/beyond-borders-transcribing-historic-maine-land-documents/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;

--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -31,7 +31,7 @@ location ~* ^/about/(?:team|publications)/?$ {
 }
 
 # FEM projects
-location ~* ^/projects/[\w-]*?/*zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -39,7 +39,7 @@ location ~* ^/projects/[\w-]*?/*zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(cl
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*hughdickinson/superwasp-black-hole-hunters/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/superwasp-black-hole-hunters/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -47,7 +47,7 @@ location ~* ^/projects/[\w-]*?/*hughdickinson/superwasp-black-hole-hunters/?(?:(
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*bogden/scarlets-and-blues/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?bogden/scarlets-and-blues/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -55,7 +55,7 @@ location ~* ^/projects/[\w-]*?/*bogden/scarlets-and-blues/?(?:(classify|about)(?
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*kmc35/peoples-contest-digital-archive/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?kmc35/peoples-contest-digital-archive/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -63,7 +63,7 @@ location ~* ^/projects/[\w-]*?/*kmc35/peoples-contest-digital-archive/?(?:(class
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*adamamiller/zwickys-stellar-sleuths/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?adamamiller/zwickys-stellar-sleuths/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -71,7 +71,7 @@ location ~* ^/projects/[\w-]*?/*adamamiller/zwickys-stellar-sleuths/?(?:(classif
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*humphrydavy/davy-notebooks-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?humphrydavy/davy-notebooks-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -79,7 +79,7 @@ location ~* ^/projects/[\w-]*?/*humphrydavy/davy-notebooks-project/?(?:(classify
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/mainehistory/[\w-]*?/*beyond-borders-transcribing-historic-maine-land-documents/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/mainehistory/(?:[\w-]*?/)?beyond-borders-transcribing-historic-maine-land-documents/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -87,7 +87,7 @@ location ~* ^/projects/mainehistory/[\w-]*?/*beyond-borders-transcribing-histori
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*msalmon/hms-nhs-the-nautical-health-service/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?msalmon/hms-nhs-the-nautical-health-service/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -95,7 +95,7 @@ location ~* ^/projects/[\w-]*?/*msalmon/hms-nhs-the-nautical-health-service/?(?:
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*nora-dot-eisner/planet-hunters-tess/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?nora-dot-eisner/planet-hunters-tess/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -103,7 +103,7 @@ location ~* ^/projects/[\w-]*?/*nora-dot-eisner/planet-hunters-tess/?(?:(classif
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*rachaelsking/corresponding-with-quakers/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?rachaelsking/corresponding-with-quakers/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -111,7 +111,7 @@ location ~* ^/projects/[\w-]*?/*rachaelsking/corresponding-with-quakers/?(?:(cla
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*mariaedgeworthletters/maria-edgeworth-letters/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mariaedgeworthletters/maria-edgeworth-letters/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -119,7 +119,7 @@ location ~* ^/projects/[\w-]*?/*mariaedgeworthletters/maria-edgeworth-letters/?(
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*pmlogan/poets-and-lovers/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?pmlogan/poets-and-lovers/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -127,7 +127,7 @@ location ~* ^/projects/[\w-]*?/*pmlogan/poets-and-lovers/?(?:(classify|about)(?:
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-african-violet-family/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-african-violet-family/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host fe-project.zooniverse.org;
@@ -135,7 +135,7 @@ location ~* ^/projects/[\w-]*?/*emhaston/the-rbge-herbarium-exploring-gesneriace
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*printmigrationnetwork/print/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?printmigrationnetwork/print/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -143,7 +143,7 @@ location ~* ^/projects/[\w-]*?/*printmigrationnetwork/print/?(?:(classify|about)
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host fe-project.zooniverse.org;
@@ -151,7 +151,7 @@ location ~* ^/projects/[\w-]*?/*profdrrogerlouismartinez-davila/deciphering-secr
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*skirmizi/ottoman-turkish-crowdsourcing/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?skirmizi/ottoman-turkish-crowdsourcing/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host fe-project.zooniverse.org;
@@ -159,7 +159,7 @@ location ~* ^/projects/[\w-]*?/*skirmizi/ottoman-turkish-crowdsourcing/?(?:(clas
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/[\w-]*?/*blicksam/transcription-task-testing/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?blicksam/transcription-task-testing/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;

--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -31,7 +31,7 @@ location ~* ^/about/(?:team|publications)/?$ {
 }
 
 # FEM projects
-location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -39,7 +39,7 @@ location ~* ^/projects/zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|ab
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/hughdickinson/superwasp-black-hole-hunters/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*hughdickinson/superwasp-black-hole-hunters/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -47,7 +47,7 @@ location ~* ^/projects/hughdickinson/superwasp-black-hole-hunters/?(?:(classify|
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/bogden/scarlets-and-blues/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*bogden/scarlets-and-blues/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -55,7 +55,7 @@ location ~* ^/projects/bogden/scarlets-and-blues/?(?:(classify|about)(?:/.+?)?)?
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/kmc35/peoples-contest-digital-archive/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*kmc35/peoples-contest-digital-archive/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -63,7 +63,7 @@ location ~* ^/projects/kmc35/peoples-contest-digital-archive/?(?:(classify|about
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/adamamiller/zwickys-stellar-sleuths/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*adamamiller/zwickys-stellar-sleuths/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -71,7 +71,7 @@ location ~* ^/projects/adamamiller/zwickys-stellar-sleuths/?(?:(classify|about)(
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/humphrydavy/davy-notebooks-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*humphrydavy/davy-notebooks-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -79,7 +79,7 @@ location ~* ^/projects/humphrydavy/davy-notebooks-project/?(?:(classify|about)(?
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/mainehistory/[\w-]*?/*beyond-borders-transcribing-historic-maine-land-documents/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -87,7 +87,7 @@ location ~* ^/projects/mainehistory/beyond-borders-transcribing-historic-maine-l
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/msalmon/hms-nhs-the-nautical-health-service/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*msalmon/hms-nhs-the-nautical-health-service/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -95,7 +95,7 @@ location ~* ^/projects/msalmon/hms-nhs-the-nautical-health-service/?(?:(classify
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/nora-dot-eisner/planet-hunters-tess/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*nora-dot-eisner/planet-hunters-tess/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -103,7 +103,7 @@ location ~* ^/projects/nora-dot-eisner/planet-hunters-tess/?(?:(classify|about)(
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/rachaelsking/corresponding-with-quakers/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*rachaelsking/corresponding-with-quakers/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -111,7 +111,7 @@ location ~* ^/projects/rachaelsking/corresponding-with-quakers/?(?:(classify|abo
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/mariaedgeworthletters/maria-edgeworth-letters/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*mariaedgeworthletters/maria-edgeworth-letters/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -119,7 +119,7 @@ location ~* ^/projects/mariaedgeworthletters/maria-edgeworth-letters/?(?:(classi
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/pmlogan/poets-and-lovers/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*pmlogan/poets-and-lovers/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -127,7 +127,7 @@ location ~* ^/projects/pmlogan/poets-and-lovers/?(?:(classify|about)(?:/.+?)?)?/
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-african-violet-family/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-african-violet-family/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host fe-project.zooniverse.org;
@@ -135,7 +135,7 @@ location ~* ^/projects/emhaston/the-rbge-herbarium-exploring-gesneriaceae-the-af
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/printmigrationnetwork/print/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*printmigrationnetwork/print/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -143,7 +143,7 @@ location ~* ^/projects/printmigrationnetwork/print/?(?:(classify|about)(?:/.+?)?
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host fe-project.zooniverse.org;
@@ -151,7 +151,7 @@ location ~* ^/projects/profdrrogerlouismartinez-davila/deciphering-secrets-unloc
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/skirmizi/ottoman-turkish-crowdsourcing/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*skirmizi/ottoman-turkish-crowdsourcing/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host fe-project.zooniverse.org;
@@ -159,7 +159,7 @@ location ~* ^/projects/skirmizi/ottoman-turkish-crowdsourcing/?(?:(classify|abou
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/blicksam/transcription-task-testing/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*blicksam/transcription-task-testing/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -31,7 +31,7 @@ location ~* ^/about/(?:team|publications)/?$ {
 }
 
 # FEM Projects app routes for project index page (optional trailing slash)
-location ~* ^/projects/[\w-]*?/*[\w-]*?/[\w-]+?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?[\w-]*?/[\w-]+?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -40,7 +40,7 @@ location ~* ^/projects/[\w-]*?/*[\w-]*?/[\w-]+?/?$ {
 }
 
 # FEM projects app: home,about and classify pages
-location ~* ^/projects/[\w-]*?/*[\w-]*/[\w-]+/(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?[\w-]*/[\w-]+/(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -31,7 +31,7 @@ location ~* ^/about/(?:team|publications)/?$ {
 }
 
 # FEM Projects app routes for project index page (optional trailing slash)
-location ~* ^/projects/[\w-]*?/[\w-]+?/?$ {
+location ~* ^/projects/[\w-]*?/*[\w-]*?/[\w-]+?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -40,7 +40,7 @@ location ~* ^/projects/[\w-]*?/[\w-]+?/?$ {
 }
 
 # FEM projects app: home,about and classify pages
-location ~* ^/projects/[\w-]*/[\w-]+/(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/[\w-]*?/*[\w-]*/[\w-]+/(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;


### PR DESCRIPTION
Add a matcher for an optional locale string in FEM project paths, between `/projects` and the project slug, eg. `/projects/zh-cn/nora-dot-eisner/planet-hunters-tess`.

The matcher should catch any of the [IETF language codes](https://en.wikipedia.org/wiki/IETF_language_tag) that we currently use, including `zh-cn` and `zh-tw`.

I've written some tests on RegExr: https://regexr.com/6m2gu

Right now, the following test link redirects in an infinite loop in PFE. This PR should fix that.
https://www.zooniverse.org/projects/test/nora-dot-eisner/planet-hunters-tess

See also https://github.com/zooniverse/Panoptes-Front-End/pull/6145
