### PR TITLE
Restrict language code matching for FEM staging

### DIFF
--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -31,7 +31,7 @@ location ~* ^/about/(?:team|publications)/?$ {
 }
 
 # FEM Projects app routes for project index page (optional trailing slash)
-location ~* "^/projects/(?:\w{2,4}?-?\w{0,4}/)?[\w-]*?/[\w-]+?/?$" {
+location ~* ^/projects/[\w-]*?/[\w-]+?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
@@ -39,7 +39,16 @@ location ~* "^/projects/(?:\w{2,4}?-?\w{0,4}/)?[\w-]*?/[\w-]+?/?$" {
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-# FEM projects app: home,about and classify pages
+# FEM Projects app routes for project index page with locale (optional trailing slash)
+location ~* "^/projects/[[:alpha:]]{2,4}(?:-[[:alnum:]]{0,4})?/[\w-]*?/[\w-]+?/?$" {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
+# FEM projects app: home,about and classify index pages, with optional locale
 location ~* ^/projects/(?:[\w-]*?/)?[\w-]*/[\w-]+/(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -31,7 +31,7 @@ location ~* ^/about/(?:team|publications)/?$ {
 }
 
 # FEM Projects app routes for project index page (optional trailing slash)
-location ~* ^/projects/(?:[\w-]*?/)?[\w-]*?/[\w-]+?/?$ {
+location ~* ^/projects/(?:\w+-?\w*?/)?[\w-]*?/[\w-]+?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -31,7 +31,7 @@ location ~* ^/about/(?:team|publications)/?$ {
 }
 
 # FEM Projects app routes for project index page (optional trailing slash)
-location ~* ^/projects/(?:\w{2,4}?-?\w{0,4}/)?[\w-]*?/[\w-]+?/?$ {
+location ~* "^/projects/(?:\w{2,4}?-?\w{0,4}/)?[\w-]*?/[\w-]+?/?$" {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -31,7 +31,7 @@ location ~* ^/about/(?:team|publications)/?$ {
 }
 
 # FEM Projects app routes for project index page (optional trailing slash)
-location ~* ^/projects/(?:\w+-?\w*?/)?[\w-]*?/[\w-]+?/?$ {
+location ~* ^/projects/(?:\w{2,4}?-?\w{0,4}/)?[\w-]*?/[\w-]+?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;


### PR DESCRIPTION
First pass at more restrictive matching for optional language codes in project home page paths, without accidentally matching Zooniverse usernames as language codes.

Tests here: https://regexr.com/6m2gu

It should match valid home page paths with or without IETF language codes eg:
- `/projects/bldigital/in-the-spotlight`
- `/projects/bldigital/in-the-spotlight/`
- `/projects/fr/bldigital/in-the-spotlight`
- `/projects/zh-cn/bldigital/in-the-spotlight`
- `/projects/es-419/bldigital/in-the-spotlight`

but it shouldn't match paths for project pages.
- `/projects/bldigital/in-the-spotlight/about`
- `/projects/bldigital/in-the-spotlight/classify`
- `/projects/bldigital/in-the-spotlight/talk`
- `/projects/bldigital/in-the-spotlight/notifications`
- `/projects/bldigital/in-the-spotlight/collections`
- `/projects/bldigital/in-the-spotlight/recents`

Closes #284.