### PR TITLE
deploy static staging on merge to master

### DIFF
--- a/.github/workflows/deploy_nginx.yaml
+++ b/.github/workflows/deploy_nginx.yaml
@@ -2,8 +2,8 @@ name: Deploy HTTP Frontend
 
 on:
   push:
-    tags:
-      - production-release
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
do not deploy staging version of this repo on production-release tag, do so on merges to master branch.

Note: jenkins file will still deploy production to merges on master via https://github.com/zooniverse/static/blob/64eca80599b801df23f50e22a7614a47dd5630ac/Jenkinsfile#L74-L75. I assume that will change once the GH deploy workflows are in. 