### PR TITLE
Use second tag to track ingress application

### DIFF
--- a/.github/workflows/apply_ingresses.yaml
+++ b/.github/workflows/apply_ingresses.yaml
@@ -44,4 +44,4 @@ jobs:
     - name: Update Ingress Tag
       run: |
         git tag production-ingress-release
-        git push origin --tags
+        git push --force origin --tags

--- a/.github/workflows/apply_ingresses.yaml
+++ b/.github/workflows/apply_ingresses.yaml
@@ -3,7 +3,7 @@ name: Apply Modified Ingresses
 on:
   push:
     tags:
-      - production-ingress
+      - production-ingresses
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/apply_ingresses.yaml
+++ b/.github/workflows/apply_ingresses.yaml
@@ -3,7 +3,7 @@ name: Apply Modified Ingresses
 on:
   push:
     tags:
-      - production-ingresses
+      - production-ingress
   workflow_dispatch:
 
 jobs:
@@ -20,13 +20,13 @@ jobs:
         cluster-name: microservices
         resource-group: kubernetes
 
-    - name: Get current deploy
+    - name: Get last applied ingress hash
       run: |
-        echo "DEPLOYED_IMAGE_TAG=$(kubectl get deployment http-frontend -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d':' -f 2)" >> $GITHUB_ENV
+        echo "CURRENT_INGRESS_HASH=$(git show-ref --tags | grep production-ingress-release | cut -d ' ' -f 1)" >> $GITHUB_ENV
 
     - name: Apply modified ingress files
       run: |
-        output=$(git diff --name-only $DEPLOYED_IMAGE_TAG ${{ github.sha }})
+        output=$(git diff --name-only $CURRENT_INGRESS_HASH ${{ github.sha }})
         echo $output | while read -r line
           do
             if [[ $line = *"kubernetes/ingress/"* ]]; then
@@ -34,3 +34,14 @@ jobs:
             fi
           done
 
+  update_ingress_tag:
+    runs-on: ubuntu-latest
+    needs: apply_ingresses
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Update Ingress Tag
+      run: |
+        git tag production-ingress-release
+        git push origin --tags

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ curl -vk http://nginx/index.html
 ## Deployment
 The nginx proxy portion of this repo is deployed to staging on pushes to the master branch via a Github Action. Deploys to production occur on pushes to the `production-release` tag and can be initiated via chatops in Slack with `lita deploy static`.
 
-Ingress application also managed via a `production-ingresses` tag. This workflow checks the diff between the currently deployed image and the current head and applies the templates that have changed. This tag can be pushed manually or via chatops with the `lita apply ingresses` command.
+Ingress application also managed via a `production-ingresses` tag, which triggers the Apply Ingresses workflow. This workflow checks the diff between the hash tagged by the `production-ingress-release` tag and the current head and applies the templates that have changed. It then updates the latter tag to indicate the updates have been made. The `production-ingreses` tag can be pushed manually or via chatops with the `lita apply ingresses` command.


### PR DESCRIPTION
Use the existing tag (`production-ingresses`) to trigger ingress application workflow. Use a second tag (`production-ingress-release`) to mark the last hash that the ingresses were checked and applied. The ingresses updated will appear in the diff between the head and that second tag and they are applied. Finally, that tag is updated to indicate the changes have been applied.