### PR TITLE
Add zoomapper.zooniverse.org ingress

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -272,6 +272,13 @@ spec:
           serviceName: seven-ten-production-app
           servicePort: 80
         path: /(.*)
+  - host: static-staging.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: http-frontend-staging
+          servicePort: 80
+        path: /(.*)
   - host: stats-staging.zooniverse.org
     http:
       paths:
@@ -335,11 +342,10 @@ spec:
           serviceName: tove-production-app
           servicePort: 80
         path: /(.*)
-  - host: static-staging.zooniverse.org
+  - host: zoomapper.azure.zooniverse.org
     http:
       paths:
       - backend:
-          serviceName: http-frontend-staging
+          serviceName: zoomapper-production-app
           servicePort: 80
         path: /(.*)
-


### PR DESCRIPTION
Moved from its own repo to live as a host on the zooniverse.org ingress rather than by itself.