### PR TITLE
Add fe-static.zooniverse.org

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -188,6 +188,13 @@ spec:
           serviceName: zooniverse-org-project-production
           servicePort: 80
         path: /(.*)
+  - host: fe-static.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: zooniverse-org-project-static
+          servicePort: 80
+        path: /(.*)
   - host: grafana-stats.zooniverse.org
     http:
       paths:


### PR DESCRIPTION
Add `fe-static.zooniverse.org`, so that we can test a NextJS deploy with static page builds.