### PR TITLE
add CI action to validate all ingress files

### DIFF
--- a/.github/workflows/validate_ingresses.yaml
+++ b/.github/workflows/validate_ingresses.yaml
@@ -23,7 +23,7 @@ jobs:
         resource-group: kubernetes
 
     - name: Dry-run validation of ingress files
-      run: kubectl apply --dry-run=client -f kubernetes/ingress/*.yaml
+      run: kubectl apply --dry-run=client -f kubernetes/ingress/
 
   deploy_slack_notification:
     name: Deploy Slack notification

--- a/.github/workflows/validate_ingresses.yaml
+++ b/.github/workflows/validate_ingresses.yaml
@@ -1,0 +1,40 @@
+name: Validate Ingresses
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate_ingresses:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Fetch tags for comparison
+      run: |
+        git fetch --prune --unshallow --tags
+
+    - name: Set the target AKS cluster
+      uses: Azure/aks-set-context@v1
+      with:
+        creds: '${{ secrets.AZURE_AKS }}'
+        cluster-name: microservices
+        resource-group: kubernetes
+
+    - name: Dry-run validation of ingress files
+      run: kubectl apply --dry-run=client -f kubernetes/ingress/*.yaml
+
+  deploy_slack_notification:
+    name: Deploy Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: validate_ingresses
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: validate_ingresses
+      status: ${{ needs.validate_ingresses.result }}
+      title: "Static ingress validation complete"
+      title_link: "https://static.zooniverse.org"
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR introduces an action that validates all the k8s ingress files on each PR. We can use this as a required CI check before merge to pickup formatting issues or api compliance issues**

** we can switch the dry-run cmd option to server as this arises, e.g. `kubectl apply --dry-run=server -f kubernetes/ingress/*.yaml`

https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply