### PR TITLE
proxy writing.galaxyzoo.org to EC2 upstream with tls termination

### DIFF
--- a/sites/star.galaxyzoo.org.conf
+++ b/sites/star.galaxyzoo.org.conf
@@ -17,3 +17,16 @@ server {
         return 301 https://www.zooniverse.org/projects/zookeeper/galaxy-zoo/;
     }
 }
+
+# writing.galaxyzoo.org TLS termination proxy to Stephen Bamford's upstream service
+# that he's self hosting on EC2 (also available at http://mygalaxies.co.uk/)
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name writing.galaxyzoo.org;
+
+    location / {
+      resolver 1.1.1.1;
+      proxy_pass  http://$host$request_uri;
+      include /etc/nginx/proxy-security-headers.conf;
+    }
+}


### PR DESCRIPTION
add server block for `writing.galaxyzoo.org` that proxies to Stephen Bamford's upstream service that he's self hosting on EC2 (also available at http://mygalaxies.co.uk/) and provide TLS termination at the K8s nginx ingress. 

This PR re-uses our *.galaxyzoo.org tls certs for the writing subdomain and avoids the need to setup a TLS cert on the upstream EC2 instance. 