### PR TITLE
Add FEM redirect for Planet Hunters TESSting

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -39,6 +39,14 @@ location ~* ^/projects/(?:[\w-]*?/)?zookeeper/galaxy-zoo-weird-and-wonderful/?(?
     include /etc/nginx/proxy-security-headers.conf;
 }
 
+location ~* ^/projects/(?:[\w-]*?/)?zookeeper/planet-hunters-tessting/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
 location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/superwasp-black-hole-hunters/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;


### PR DESCRIPTION
## PR Overview

Related PR: https://github.com/zooniverse/Panoptes-Front-End/pull/6176

This PR puts the **Planet Hunters TESSting** project on the FEM codebase.

- Affected URL: https://www.zooniverse.org/projects/zookeeper/planet-hunters-tessting and subpages
- Planet Hunters TESSting is the "test copy" of Planet Hunters TESS
  - Note that the owner is zookeeper, not nora-dot-eisner
- In Sep 2022, we want to use this "test copy" to ask users to try out the new Quick Talk feature.

### Status

DO NOT MERGE YET.

- We are currently waiting for the project to change its name from ["Planet Hunters TESS"](https://frontend.preview.zooniverse.org/projects/zookeeper/planet-hunters-tess) to "Planet Hunters TESSting".
- (As of 13 Sep 15:00 BST, the "test copy" shares the exact same slug as the original, which is why we're renaming - to avoid confusion)