### PR TITLE
Add Community Catalog (community-catalog) static proxy config 

### DIFF
--- a/sites/community-catalog.zooniverse.org.conf
+++ b/sites/community-catalog.zooniverse.org.conf
@@ -1,0 +1,15 @@
+server {
+  include /etc/nginx/ssl.default.conf;
+  server_name community-catalog.zooniverse.org;
+
+  location / {
+      resolver 8.8.8.8;
+
+      rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/community-catalog.zooniverse.org$request_uri;
+
+      # This is a hack to get nginx to discard the uri in the proxy request
+      set $uri_path "community-catalog.zooniverse.org/";
+      proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$uri_path;
+      include /etc/nginx/az-proxy-headers.conf;
+  }
+}


### PR DESCRIPTION
## PR Overview

Associated with: Communities & Crowds project (2022), [community-catalog](https://github.com/zooniverse/community-catalog) custom front end

This PR adds the static proxy config for a new Zooniverse website, https://community-catalog.zooniverse.org

Dev note: the [zoo-notes proxy config](https://github.com/zooniverse/static/blob/master/sites/zoo-notes.zooniverse.org.conf) was used as a template