### PR TITLE
Add listmonk to zooniverse.org ingress

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -350,6 +350,16 @@ spec:
             name: http-frontend
             port:
               number: 80
+  - host: listmonk.zooniverse.org
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: listmonk
+            port:
+              number: 80
   - host: notifications-staging.zooniverse.org
     http:
       paths:


### PR DESCRIPTION
This will likely change to occupy `lists.` once mailman is retired. Or perhaps it'll take `emails.` or something. For now, this is the least ambiguous option.