### PR TITLE
URL rewrite for astopy/black-hole-hunters

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -238,3 +238,11 @@ location ~* ^/projects/(?:[\w-]*?/)?aeuk/elephant-id/?(?:(classify|about)(?:/.+?
 
     include /etc/nginx/proxy-security-headers.conf;
 }
+
+location ~* ^/projects/(?:[\w-]*?/)?astopy/black-hole-hunters/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}


### PR DESCRIPTION
Route `astopy/black-hole-hunters` to the Next.js project app.

See https://github.com/zooniverse/Panoptes-Front-End/pull/6804.