### PR TITLE
Allow short usernames in FEM staging projects

### DIFF
--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -40,7 +40,16 @@ location ~* ^/projects/[\w-]*?/[\w-]+?/?$ {
 }
 
 # FEM Projects app routes for project index page with locale (optional trailing slash)
-location ~* "^/projects/[[:alpha:]]{2,4}(?:-[[:alnum:]]{0,4})?/[\w-]*?/[\w-]+?/?$" {
+location ~* "^/projects/[[:alpha:]]{2,3}(?:-[[:alnum:]]{0,4})?/[\w-]*?/[\w-]+?/?$" {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
+# FEM Projects app routes for project index page with the test locale (optional trailing slash)
+location ~* "^/projects/test/[\w-]*?/[\w-]+?/?$" {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;


### PR DESCRIPTION
Match 2 or 3 characters as language codes in FEM staging URLs. Add a specific `location` block for the test locale.