### PR TITLE
Redirect Voyages In Time project

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -91,6 +91,10 @@ server {
         return 301 /projects/laac-lscp/maturity-of-baby-sounds$1$2$is_args$query_string;
     }
 
+    location ~* ^/projects/sarah-middle/voyages-in-time(/?)(.*?)\/?$ {
+        return 301 /projects/toolsofknowledge/voyages-in-time$1$2$is_args$query_string;
+    }
+
     # ensure the js and CSS assets are served on the same or subdomain
     location ~ \.(js|css)$ {
         resolver 8.8.8.8;


### PR DESCRIPTION
The Voyages in Time project has requested we redirect the project url before an owner change - https://www.zooniverse.org/projects/sarah-middle/voyages-in-time - to the current project url - https://www.zooniverse.org/projects/toolsofknowledge/voyages-in-time, as the former/old url was shared publicly at conferences.