### PR TITLE
Redirect CSA domain to Zooniverse

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -192,7 +192,7 @@ server {
 server {
     include /etc/nginx/ssl.default.conf;
     server_name citizensciencealliance.org;
-    return 301 http://www.citizensciencealliance.org$request_uri;
+    return 301 https://www.zooniverse.org;
 }
 
 server {


### PR DESCRIPTION
Redirect citizensciencealliance.org domain to https://www.zooniverse.org. Leaves intact the proposals.citizensciencealliance.org redirect to zooniverse.org/lab. 

There's a mail.citizensciencealliance.org DNS record set up that might have been used for gmail at one point but is likely defunct. Once this is confirmed, I'll remove it.