### PR TITLE
FEM redirect: Documentation Detectives

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -294,3 +294,11 @@ location ~* ^/projects/(?:[\w-]*?/)?johandmi/arctic-archives-unraveling-greenlan
 
     include /etc/nginx/proxy-security-headers.conf;
 }
+
+location ~* ^/projects/(?:[\w-]*?/)?bmtcollections/documentation-detectives-transcribing-accession-registers/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}


### PR DESCRIPTION
Add FEM redirects for Documentation Detectives (Project 21982)

PFE PR: https://github.com/zooniverse/Panoptes-Front-End/pull/7049
Staging URL for Project: https://pr-7049.pfe-preview.zooniverse.org/projects/bmtcollections/documentation-detectives-transcribing-accession-registers

Target Deploy Date: Feb 26