### PR TITLE
Add fe-root to FEM staging redirects

### DIFF
--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -1,7 +1,9 @@
 set $fe_project_uri "https://fe-project.preview.zooniverse.org";
 set $fe_content_pages_uri "https://fe-content-pages.preview.zooniverse.org";
+set $fe-root_uri "https://fe-root.preview.zooniverse.org";
 set $fe_project_host "fe-project.preview.zooniverse.org";
 set $fe_content_pages_host "fe-content-pages.preview.zooniverse.org";
+set $fe-root_host "fe-root.preview.zooniverse.org";
 
 # Project app data and static files
 location ~* ^/projects/(?:_next|assets)/.+?$ {
@@ -17,6 +19,15 @@ location ~* ^/about/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_content_pages_uri;
     proxy_set_header Host $fe_content_pages_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
+# Root app data and static files
+location ~* ^/(?:_next|assets)/.+?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe-root_uri;
+    proxy_set_header Host $fe-root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }
@@ -62,6 +73,24 @@ location ~* ^/projects/(?:[\w-]*?/)?[\w-]*/[\w-]+/(?:(classify|about)(?:/.+?)?)?
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
+# FEM Root app routes for users pages (optional trailing slash)
+location ~* ^/users/[\w-]+/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe-root_uri;
+    proxy_set_header Host $fe-root_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
+# FEM Root app routes for user groups pages (optional trailing slash)
+location ~* ^/groups/[\w-]+/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe-root_uri;
+    proxy_set_header Host $fe-root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }


### PR DESCRIPTION
Complimentary to zooniverse/front-end-monorepo/pull/6032.

- set fe-root staging uri and host
- create location block for fe-root (aka app-root) assets
- create location block for fe-root `/users/` and `/groups/` subpaths