### PR TITLE
Update all shared action versions to latest

### DIFF
--- a/.github/workflows/apply_ingresses.yaml
+++ b/.github/workflows/apply_ingresses.yaml
@@ -17,10 +17,13 @@ jobs:
       run: |
         git fetch --prune --unshallow --tags
 
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_AKS }}
+
     - name: Set the target AKS cluster
       uses: Azure/aks-set-context@v4.0.0
       with:
-        creds: '${{ secrets.AZURE_AKS }}'
         cluster-name: microservices
         resource-group: kubernetes
 

--- a/.github/workflows/apply_ingresses.yaml
+++ b/.github/workflows/apply_ingresses.yaml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
 
     - name: Fetch tags for comparison
       run: |
         git fetch --prune --unshallow --tags
 
     - name: Set the target AKS cluster
-      uses: Azure/aks-set-context@v1
+      uses: Azure/aks-set-context@v4.0.0
       with:
         creds: '${{ secrets.AZURE_AKS }}'
         cluster-name: microservices
@@ -44,7 +44,7 @@ jobs:
     needs: apply_ingresses
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
 
     - name: Update Ingress Tag
       run: |

--- a/.github/workflows/deploy_nginx_production.yaml
+++ b/.github/workflows/deploy_nginx_production.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
 
     - name: Set the target AKS cluster
-      uses: Azure/aks-set-context@v1
+      uses: Azure/aks-set-context@v4.0.0
       with:
         creds: '${{ secrets.AZURE_AKS }}'
         cluster-name: microservices

--- a/.github/workflows/deploy_nginx_production.yaml
+++ b/.github/workflows/deploy_nginx_production.yaml
@@ -13,10 +13,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4.1.1
 
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_AKS }}
+
     - name: Set the target AKS cluster
       uses: Azure/aks-set-context@v4.0.0
       with:
-        creds: '${{ secrets.AZURE_AKS }}'
         cluster-name: microservices
         resource-group: kubernetes
 

--- a/.github/workflows/deploy_nginx_staging.yaml
+++ b/.github/workflows/deploy_nginx_staging.yaml
@@ -11,20 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3.1.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         context: .
         push: true
@@ -57,7 +57,7 @@ jobs:
     needs: test_configuration
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -75,14 +75,14 @@ jobs:
     needs: push_latest_tag
     steps:
       - name: Set the target AKS cluster
-        uses: Azure/aks-set-context@v1
+        uses: Azure/aks-set-context@v4.0.0
         with:
           creds: '${{ secrets.AZURE_AKS }}'
           cluster-name: microservices
           resource-group: kubernetes
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
 
       - name: Modify & apply template
         run: |

--- a/.github/workflows/deploy_nginx_staging.yaml
+++ b/.github/workflows/deploy_nginx_staging.yaml
@@ -74,10 +74,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: push_latest_tag
     steps:
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_AKS }}
+
       - name: Set the target AKS cluster
         uses: Azure/aks-set-context@v4.0.0
         with:
-          creds: '${{ secrets.AZURE_AKS }}'
           cluster-name: microservices
           resource-group: kubernetes
 

--- a/.github/workflows/validate_ingresses.yaml
+++ b/.github/workflows/validate_ingresses.yaml
@@ -15,10 +15,13 @@ jobs:
       run: |
         git fetch --prune --unshallow --tags
 
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_AKS }}
+
     - name: Set the target AKS cluster
       uses: Azure/aks-set-context@v4.0.0
       with:
-        creds: '${{ secrets.AZURE_AKS }}'
         cluster-name: microservices
         resource-group: kubernetes
 

--- a/.github/workflows/validate_ingresses.yaml
+++ b/.github/workflows/validate_ingresses.yaml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.1.1
 
     - name: Fetch tags for comparison
       run: |
         git fetch --prune --unshallow --tags
 
     - name: Set the target AKS cluster
-      uses: Azure/aks-set-context@v1
+      uses: Azure/aks-set-context@v4.0.0
       with:
         creds: '${{ secrets.AZURE_AKS }}'
         cluster-name: microservices


### PR DESCRIPTION
Node 16 is deprecated. Update all shared (github, docker, azure) actions to latest.