### PR TITLE
Add fe-root ingress

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -280,6 +280,16 @@ spec:
             name: zooniverse-org-project-production
             port:
               number: 80
+  - host: fe-root.preview.zooniverse.org
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: zooniverse-org-root-staging
+            port:
+              number: 80
   - host: fe-static.zooniverse.org
     http:
       paths:


### PR DESCRIPTION
Configure the http-frontend to point traffic to `fe-root.preview.zooniverse.org` at the `zooniverse-org-root-staging` service.

edit: the service mentioned above will only exist when https://github.com/zooniverse/front-end-monorepo/pull/6032/ merges & deploys.