### PR TITLE
Revert FEM migration for Walleye project

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -375,14 +375,6 @@ location ~* ^/projects/(?:[\w-]*?/)?victorav/spyfish-aotearoa/?(?:(classify|abou
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?dangogh/wheres-walleye/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    resolver 1.1.1.1;
-    proxy_pass $fe_project_uri;
-    proxy_set_header Host $fe_project_host;
-
-    include /etc/nginx/proxy-security-headers.conf;
-}
-
 location ~* ^/projects/(?:[\w-]*?/)?bcosentino/squirrelmapper/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;


### PR DESCRIPTION
Newly migrated project [Where's Walleye](https://www.zooniverse.org/projects/dangogh/wheres-walleye) is having issues with FEM. This migrates the project back but will require a Friday deploy to get out quickly.

PFE PR: https://github.com/zooniverse/Panoptes-Front-End/pull/7086