### PR TITLE
Revert FEM migration of Burrowing Owl project

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -311,14 +311,6 @@ location ~* ^/projects/(?:[\w-]*?/)?bluejackets/civil-war-bluejackets/?(?:(class
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sandiegozooglobal/wildwatch-burrowing-owl/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    resolver 1.1.1.1;
-    proxy_pass $fe_project_uri;
-    proxy_set_header Host $fe_project_host;
-
-    include /etc/nginx/proxy-security-headers.conf;
-}
-
 location ~* ^/projects/(?:[\w-]*?/)?leinwc/island-critter-cam/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;


### PR DESCRIPTION
Same as the last one. `sandiegozooglobal/wildwatch-burrowing-owl` needs an emergency un-migration back to FEM.