### PR TITLE
Update Snapshot Serengeti Redirect

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -137,14 +137,14 @@ server {
 
 server {
     include /etc/nginx/ssl.default.conf;
-    server_name snapshotserengeti.org;
-    return 301 http://www.snapshotserengeti.org$request_uri;
+    server_name snapshotserengeti.org www.snapshotserengeti.org;
+    return 301 https://www.zooniverse.org/projects/zooniverse/snapshot-serengeti;
 }
 
 server {
     include /etc/nginx/ssl.default.conf;
     server_name data.snapshotserengeti.org;
-    return 301 http://www.snapshotserengeti.org/#/data;
+    return 301 https://www.zooniverse.org/projects/zooniverse/snapshot-serengeti/about/results;
 }
 
 server {


### PR DESCRIPTION
This PR removes the current redirect of snapshotserengeti.org to the old pre-Panoptes custom frontend that then redirects to the current Panoptes Project (now/currently on FEM), and instead redirects straight to the Panoptes project location (URL = https://www.zooniverse.org/projects/zooniverse/snapshot-serengeti).