### PR TITLE
Update zoo ingress to point at new aggregation service

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -117,7 +117,7 @@ spec:
         path: /
         backend:
           service:
-            name: aggregation-caesar
+            name: aggregation-production-app
             port:
               number: 80
   - host: caesar-staging.zooniverse.org


### PR DESCRIPTION
While deploying the batch aggregation feature to aggregation-for-caesar, I added a staging deployment and renamed the production service from "aggregation-caesar" to "aggregation-production-app". This PR updates the zooniverse.org ingress to point at the new service, allowing both to exist until testing is complete and the old service is deleted.

I have already applied this change manually, this PR updates the code and should be followed by running the ingress application job via lita to point the tag at the correct commit.