### PR TITLE
Update PRN redirect: Sudan Project Launch 2024

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -504,7 +504,7 @@ server {
 server {
     include /etc/nginx/ssl.default.conf;
     server_name planetaryresponsenetwork.org planetaryresponsenetwork.net planetaryresponsenetwork.com www.planetaryresponsenetwork.org www.planetaryresponsenetwork.net www.planetaryresponsenetwork.com;
-    return 301 https://www.zooniverse.org/projects/mrniaboc/planetary-response-network-hurricane-dorian;
+    return 301 https://www.zooniverse.org/projects/alicemead/sudan-road-access-logistics-cluster;
 }
 
 server {


### PR DESCRIPTION
Updating the Planetary Response Network domains/URLs (planetaryresponsenetwork.org, planetaryresponsenetwork.net, planetaryresponsenetwork.com, www.planetaryresponsenetwork.org, www.planetaryresponsenetwork.net, www.planetaryresponsenetwork.com) to point to latest project launch -- [Sudan Road Access: Logistics Cluster](https://www.zooniverse.org/projects/alicemead/sudan-road-access-logistics-cluster)

Timeline: ASAP for public launch on 15 July 2024