### PR TITLE
FEM Switcheroo: Phase One

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -290,6 +290,16 @@ spec:
             name: zooniverse-org-root-staging
             port:
               number: 80
+  - host: fe-root.zooniverse.org
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: zooniverse-org-root-production
+            port:
+              number: 80
   - host: fe-static.zooniverse.org
     http:
       paths:

--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -1,7 +1,7 @@
 set $fe_project_uri "https://fe-project.zooniverse.org";
-set $fe_content_pages_uri "https://fe-content-pages.zooniverse.org";
+set $fe_root_uri "https://fe-root.zooniverse.org";
 set $fe_project_host "fe-project.zooniverse.org";
-set $fe_content_pages_host "fe-content-pages.zooniverse.org";
+set $fe_root_host "fe-root.zooniverse.org";
 
 # Project app data and static files
 location ~* ^/projects/(?:_next|assets)/.+?$ {
@@ -12,20 +12,20 @@ location ~* ^/projects/(?:_next|assets)/.+?$ {
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-# About pages data and static files
-location ~* ^/about/(?:_next|assets)/.+?$ {
+# Zooniverse About pages, prefix match
+location /about {
     resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-# Zooniverse About pages
-location ~* ^/about/(?:team|publications)/?$ {
+# Zooniverse Get Involved pages, prefix match
+location /get-involved {
     resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -1,8 +1,6 @@
 set $fe_project_uri "https://fe-project.preview.zooniverse.org";
-set $fe_content_pages_uri "https://fe-content-pages.preview.zooniverse.org";
 set $fe_root_uri "https://fe-root.preview.zooniverse.org";
 set $fe_project_host "fe-project.preview.zooniverse.org";
-set $fe_content_pages_host "fe-content-pages.preview.zooniverse.org";
 set $fe_root_host "fe-root.preview.zooniverse.org";
 
 # Project app data and static files
@@ -10,15 +8,6 @@ location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;
-
-    include /etc/nginx/proxy-security-headers.conf;
-}
-
-# About pages data and static files
-location ~* ^/about/(?:_next|assets)/.+?$ {
-    resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }
@@ -33,10 +22,19 @@ location ~* ^/(?:_next|assets)/.+?$ {
 }
 
 # Zooniverse About pages
-location ~* ^/about/(?:team|publications)/?$ {
+location /about {
     resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
+# Zooniverse Get Involved pages
+location /get-involved {
+    resolver 1.1.1.1;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }


### PR DESCRIPTION
* Migrates `fe-content-pages` routes to `fe-root`. Locations `/about` and `/get-involved` now use prefix matches that point to `fe-root.zooniverse.org`. Included this change in both production and staging redirect configurations (with staging pointing to fe-root.preview).
* Removes the `/about/(_next|assets)/` location block since that's covered by the prefix match.
* Adds the fe-root.zooniverse.org host to the zooniverse.org ingress. Requires https://github.com/zooniverse/front-end-monorepo/pull/6273 to deploy first to create that service.

When this merges and deploys to staging, it will override the current, manually-tagged staging deploy. Changes in this PR can then be tested on static-staging.zooniverse.org which will once again be at parity with production, plus this PR. Subsequently deploying to production will complete Phase One of the Switcheroo in preparation for the Great Switch Pull next week.

edit: Requesting a handful of reviewers who might wanna take a look. If no one can get to it, I can smash the admin merge button. 