### PR TITLE
Copy frontend.preview config to static-staging

### DIFF
--- a/sites/static-staging.zooniverse.org.conf
+++ b/sites/static-staging.zooniverse.org.conf
@@ -2,7 +2,7 @@ server {
     set $proxy_path "www.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
     include /etc/nginx/fem-staging-redirects.conf;
-    server_name frontend.preview.zooniverse.org;
+    server_name static-staging.zooniverse.org;
 
     rewrite ^/lab-policies$ https://help.zooniverse.org/getting-started/lab-policies permanent;
     rewrite ^/glossary$ https://help.zooniverse.org/getting-started/glossary permanent;

--- a/sites/static-staging.zooniverse.org.conf
+++ b/sites/static-staging.zooniverse.org.conf
@@ -1,11 +1,131 @@
 server {
+    set $proxy_path "www.zooniverse.org";
     include /etc/nginx/ssl.default.conf;
-    server_name static-staging.zooniverse.org;
+    include /etc/nginx/fem-staging-redirects.conf;
+    server_name frontend.preview.zooniverse.org;
+
+    rewrite ^/lab-policies$ https://help.zooniverse.org/getting-started/lab-policies permanent;
+    rewrite ^/glossary$ https://help.zooniverse.org/getting-started/glossary permanent;
+
+    rewrite ^/help$ https://help.zooniverse.org/getting-started permanent;
+    rewrite ^/help/best-practices$ https://help.zooniverse.org/best-practices permanent;
+    rewrite ^/help/glossary$ https://help.zooniverse.org/getting-started/glossary permanent;
+    rewrite ^/help/lab-policies$ https://help.zooniverse.org/getting-started/lab-policies permanent;
+    rewrite ^/help/example$ https://help.zooniverse.org/getting-started/example permanent;
+
+    rewrite ^/lab-best-practices$ https://help.zooniverse.org/best-practices permanent;
+    rewrite ^/lab-best-practices/introduction$ https://help.zooniverse.org/best-practices permanent;
+    rewrite ^/lab-best-practices/great-project$ https://help.zooniverse.org/best-practices/1-great-project permanent;
+    rewrite ^/lab-best-practices/launch-rush$ https://help.zooniverse.org/best-practices/2-launch-rush permanent;
+    rewrite ^/lab-best-practices/the-long-haul$ https://help.zooniverse.org/best-practices/3-long-haul permanent;
+    rewrite ^/lab-best-practices/resources$ https://help.zooniverse.org/best-practices/4-resources permanent;
+
+    location /password/reset {
+        return 301 /reset-password;
+    }
+
+    location /projects/current {
+        return 301 /;
+    }
+
+    location /signup {
+        return 301 /accounts/register;
+    }
+
+    location /publications {
+        return 301 /about/publications;
+    }
+
+    location /api/events {
+        return 301 https://panoptes.zooniverse.org/api/events;
+    }
+
+    location /account/newsletters {
+        return 301 /settings/email;
+    }
+
+    location ~* /project(_|-)?builder$ {
+        return 301 /lab;
+    }
+
+    location /account/settings {
+        return 301 /settings;
+    }
+
+    location /home {
+        return 301 /;
+    }
+
+    location /team {
+        return 301 /about/team;
+    }
+
+    location ~* /project/.* {
+        return 301 /projects;
+    }
+
+    location /education {
+        return 301 /about/education;
+    }
+
+    location /contact {
+        return 301 /about/contact;
+    }
+
+    location ~* ^/projects/meredithspalmer/(cedar-creek-eyes-on-the-wild/?)(.*?)\/?$ {
+        return 301 /projects/forestis/$1$2$is_args$query_string;
+    }
+
+    location ~* ^/projects/karilint/the-cradle-of-mankind(/?)(.*?)\/?$ {
+        return 301 /projects/karilint/cradle-of-humanity$1$2$is_args$query_string;
+    }
+
+    location ~* ^/projects/cseidenstuecker/every-name-counts(/?)(.*?)\/?$ {
+        return 301 /projects/arolsen-archives/every-name-counts$1$2$is_args$query_string;
+    }
+
+    location ~* ^/projects/kevinesolberg/mapping-prejudice(/?)(.*?)\/?$ {
+        return 301 /projects/mappingprejudice/mapping-prejudice$1$2$is_args$query_string;
+    }
+
+    location ~* ^/projects/chiarasemenzin/maturity-of-baby-sounds(/?)(.*?)\/?$ {
+        return 301 /projects/laac-lscp/maturity-of-baby-sounds$1$2$is_args$query_string;
+    }
+
+    # ensure the js and CSS assets are served on the same or subdomain
+    location ~ \.(js|css)$ {
+        resolver 1.1.1.1;
+        proxy_pass  https://zooniversestatic.z13.web.core.windows.net/$proxy_path$request_uri;
+        include /etc/nginx/az-proxy-headers.conf;
+    }
+
+    # unsubscribe route uses redirects between panoptes and the UI code
+    # so needs it's own location block to handle the form submission POST
+    # and the GET page loading (PFE routing handles the path)
+    location /unsubscribe {
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+
+        resolver 1.1.1.1;
+        if ($request_method ~ ^(GET|HEAD)$) {
+            proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
+            set $proxy_host_header "zooniversestatic.z13.web.core.windows.net";
+        }
+        if ($request_method = POST) {
+            proxy_pass             https://panoptes.zooniverse.org$request_uri;
+            set $proxy_host_header "panoptes.zooniverse.org";
+        }
+        proxy_set_header Host $proxy_host_header;
+        proxy_redirect         /$host/ /;
+
+        include /etc/nginx/az-proxy-headers.conf;
+    }
 
     location / {
-      resolver 1.1.1.1;
+        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
-      include /etc/nginx/az-proxy-headers.conf;
-      proxy_pass https://zooniversestatic.z13.web.core.windows.net/$request_uri;
+        resolver 1.1.1.1;
+        proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
+
+        include /etc/nginx/az-proxy-headers.conf;
     }
 }


### PR DESCRIPTION
Sets up static-staging.zooniverse.org with the same nginx config as frontend.preview, which is itself a modified copy of www.zooniverse.org.conf. This should fix asset loading and allow for a bit of switcheroo phase one testing through the staging proxy. static-staging gets revamped again as soon as the fe-root updates are deployed, and this will also be a more accurate starting point to implement phase two changes.

