### PR TITLE
Revert /about and /get-involved to content-pages app

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -1,6 +1,8 @@
 set $fe_project_uri "https://fe-project.zooniverse.org";
+set $fe_content_pages_uri "https://fe-content-pages.zooniverse.org";
 set $fe_root_uri "https://fe-root.zooniverse.org";
 set $fe_project_host "fe-project.zooniverse.org";
+set $fe_content_pages_host "fe-content-pages.zooniverse.org";
 set $fe_root_host "fe-root.zooniverse.org";
 
 # Project app data and static files
@@ -24,8 +26,8 @@ location ~* ^/(?:_next|assets)/.+?$ {
 # Zooniverse About pages, prefix match
 location /about {
     resolver 1.1.1.1;
-    proxy_pass $fe_root_uri;
-    proxy_set_header Host $fe_root_host;
+    proxy_pass $fe_content_pages_uri;
+    proxy_set_header Host $fe_content_pages_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }
@@ -33,8 +35,8 @@ location /about {
 # Zooniverse Get Involved pages, prefix match
 location /get-involved {
     resolver 1.1.1.1;
-    proxy_pass $fe_root_uri;
-    proxy_set_header Host $fe_root_host;
+    proxy_pass $fe_content_pages_uri;
+    proxy_set_header Host $fe_content_pages_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -1,6 +1,8 @@
 set $fe_project_uri "https://fe-project.preview.zooniverse.org";
+set $fe_content_pages_uri "https://fe-content-pages.preview.zooniverse.org";
 set $fe_root_uri "https://fe-root.preview.zooniverse.org";
 set $fe_project_host "fe-project.preview.zooniverse.org";
+set $fe_content_pages_host "fe-content-pages.preview.zooniverse.org";
 set $fe_root_host "fe-root.preview.zooniverse.org";
 
 # Project app data and static files
@@ -24,8 +26,8 @@ location ~* ^/(?:_next|assets)/.+?$ {
 # Zooniverse About pages
 location /about {
     resolver 1.1.1.1;
-    proxy_pass $fe_root_uri;
-    proxy_set_header Host $fe_root_host;
+    proxy_pass $fe_content_pages_uri;
+    proxy_set_header Host $fe_content_pages_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }
@@ -33,8 +35,8 @@ location /about {
 # Zooniverse Get Involved pages
 location /get-involved {
     resolver 1.1.1.1;
-    proxy_pass $fe_root_uri;
-    proxy_set_header Host $fe_root_host;
+    proxy_pass $fe_content_pages_uri;
+    proxy_set_header Host $fe_content_pages_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }


### PR DESCRIPTION
CDN issues are making the new app router in the fe-root app cause issues in production. This reverts the routing changes of `/about/*` and `/get-involved/*` to point to the still-extant fe-content-pages app, which has been updated with the look&feel of the newer fe-root app. 

When the CDN issues are addressed, this can be undone and fe-content-pages can be fully deprecated.