### PR TITLE
Add route for /mock

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -5,6 +5,15 @@ set $fe_project_host "fe-project.zooniverse.org";
 set $fe_content_pages_host "fe-content-pages.zooniverse.org";
 set $fe_root_host "fe-root.zooniverse.org";
 
+# Mock route to test per-path query param caching
+location  /mock {
+    resolver 1.1.1.1;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
 # Project app data and static files
 location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -5,6 +5,15 @@ set $fe_project_host "fe-project.preview.zooniverse.org";
 set $fe_content_pages_host "fe-content-pages.preview.zooniverse.org";
 set $fe_root_host "fe-root.preview.zooniverse.org";
 
+# Mock route to test per-path query param caching
+location  /mock {
+    resolver 1.1.1.1;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
 # Project app data and static files
 location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;


### PR DESCRIPTION
Adds new route pointed at fe-root app to test caching behavior of the AFD CDN.