### PR TITLE
Serve /mock assets from fe-root

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -6,7 +6,16 @@ set $fe_content_pages_host "fe-content-pages.zooniverse.org";
 set $fe_root_host "fe-root.zooniverse.org";
 
 # Mock route to test per-path query param caching
-location  /mock {
+location /mock {
+    resolver 1.1.1.1;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
+# Mock route, fe-root app data and static files
+location ~* ^/mock/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_root_uri;
     proxy_set_header Host $fe_root_host;

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -14,6 +14,15 @@ location  /mock {
     include /etc/nginx/proxy-security-headers.conf;
 }
 
+# Mock route, fe-root app data and static files
+location ~* ^/mock/(?:_next|assets)/.+?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
 # Project app data and static files
 location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;


### PR DESCRIPTION
Route `/mock/(_next|assets)` to fe-root for CDN testing purposes. fe-root's basePath has been changed to allow RSC queries to work at `/mock` and it needs to be able to load its assets from that path.