### PR TITLE
Redeploy fe-root for /about and /get-involved pages

### DIFF
--- a/nginx-fem-redirects.conf
+++ b/nginx-fem-redirects.conf
@@ -5,24 +5,6 @@ set $fe_project_host "fe-project.zooniverse.org";
 set $fe_content_pages_host "fe-content-pages.zooniverse.org";
 set $fe_root_host "fe-root.zooniverse.org";
 
-# Mock route to test per-path query param caching
-location /mock {
-    resolver 1.1.1.1;
-    proxy_pass $fe_root_uri;
-    proxy_set_header Host $fe_root_host;
-
-    include /etc/nginx/proxy-security-headers.conf;
-}
-
-# Mock route, fe-root app data and static files
-location ~* ^/mock/(?:_next|assets)/.+?$ {
-    resolver 1.1.1.1;
-    proxy_pass $fe_root_uri;
-    proxy_set_header Host $fe_root_host;
-
-    include /etc/nginx/proxy-security-headers.conf;
-}
-
 # Project app data and static files
 location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
@@ -35,8 +17,8 @@ location ~* ^/projects/(?:_next|assets)/.+?$ {
 # Root app data and static files
 location ~* ^/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }
@@ -44,8 +26,8 @@ location ~* ^/(?:_next|assets)/.+?$ {
 # Zooniverse About pages, prefix match
 location /about {
     resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }
@@ -53,8 +35,8 @@ location /about {
 # Zooniverse Get Involved pages, prefix match
 location /get-involved {
     resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }

--- a/nginx-fem-staging-redirects.conf
+++ b/nginx-fem-staging-redirects.conf
@@ -5,24 +5,6 @@ set $fe_project_host "fe-project.preview.zooniverse.org";
 set $fe_content_pages_host "fe-content-pages.preview.zooniverse.org";
 set $fe_root_host "fe-root.preview.zooniverse.org";
 
-# Mock route to test per-path query param caching
-location  /mock {
-    resolver 1.1.1.1;
-    proxy_pass $fe_root_uri;
-    proxy_set_header Host $fe_root_host;
-
-    include /etc/nginx/proxy-security-headers.conf;
-}
-
-# Mock route, fe-root app data and static files
-location ~* ^/mock/(?:_next|assets)/.+?$ {
-    resolver 1.1.1.1;
-    proxy_pass $fe_root_uri;
-    proxy_set_header Host $fe_root_host;
-
-    include /etc/nginx/proxy-security-headers.conf;
-}
-
 # Project app data and static files
 location ~* ^/projects/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
@@ -35,8 +17,8 @@ location ~* ^/projects/(?:_next|assets)/.+?$ {
 # Root app data and static files
 location ~* ^/(?:_next|assets)/.+?$ {
     resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }
@@ -44,8 +26,8 @@ location ~* ^/(?:_next|assets)/.+?$ {
 # Zooniverse About pages
 location /about {
     resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }
@@ -53,8 +35,8 @@ location /about {
 # Zooniverse Get Involved pages
 location /get-involved {
     resolver 1.1.1.1;
-    proxy_pass $fe_content_pages_uri;
-    proxy_set_header Host $fe_content_pages_host;
+    proxy_pass $fe_root_uri;
+    proxy_set_header Host $fe_root_host;
 
     include /etc/nginx/proxy-security-headers.conf;
 }


### PR DESCRIPTION
Removes the testing `/mock` routes and reroutes `/about*` and `/get-involved*` to fe-root app. This facilitated testing of the CDN behavior and its ability to cache query params to avoid unintentionally caching nextjs RSC payloads. This test was successful and this reverts the paths back to their originally intended routes.