### PR TITLE
Fix staging asset regex

### DIFF
--- a/nginx-pfe-staging-redirects.conf
+++ b/nginx-pfe-staging-redirects.conf
@@ -10,7 +10,7 @@ location ~* ^/projects/(?:_next|assets)/.+?$ {
 }
 
 # PFE assets
-location ~ \.(js|css)$ {
+location ~ ^/[\w-]+\.(js|css)$ {
     resolver 1.1.1.1;
     proxy_pass  https://zooniversestatic.z13.web.core.windows.net/$proxy_path$request_uri;
     include /etc/nginx/az-proxy-headers.conf;


### PR DESCRIPTION
PFE JS/css assets are served at the root. Update the staging regex matcher to only match the root and not _all_ JS and CSS files. 