### PR TITLE
Move example FEM project redirect above /projects prefix matcher

### DIFF
--- a/nginx-pfe-staging-redirects.conf
+++ b/nginx-pfe-staging-redirects.conf
@@ -34,6 +34,15 @@ location ~* ^/users/[\w-]+/((collections|favorites|message)?)/?$ {
     include /etc/nginx/az-proxy-headers.conf;
 }
 
+# Example FEM project redirect
+location ~* ^/projects/(?:[\w-]*?/)?brooke/i-fancy-cats/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass "https://fe-project.preview.zooniverse.org";
+    proxy_set_header Host fe-project.preview.zooniverse.org;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}
+
 # Default: /project/* to PFE
 # Can be overridden by directives in nginx-project-redirects.conf
 location ~* ^/projects {
@@ -72,13 +81,4 @@ location /unsubscribe {
     proxy_redirect         /$host/ /;
 
     include /etc/nginx/az-proxy-headers.conf;
-}
-
-# Example FEM project redirect
-location ~* ^/projects/(?:[\w-]*?/)?brooke/i-fancy-cats/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    resolver 1.1.1.1;
-    proxy_pass "https://fe-project.preview.zooniverse.org";
-    proxy_set_header Host fe-project.preview.zooniverse.org;
-
-    include /etc/nginx/proxy-security-headers.conf;
 }


### PR DESCRIPTION
The example is meant to allow testing of the form & function of a typical FEM project redirect. However, due to being first in the file, `^/projects` was matching first and causing this test to not work.

This is why the `fem-projects-redirects.conf` include comes before the rest of the `pfe-redirects.conf` in the production `www.zooniverse.org.conf` file.