### PR TITLE
Update users regex to allow certain punctuation

### DIFF
--- a/nginx-pfe-redirects.conf
+++ b/nginx-pfe-redirects.conf
@@ -17,7 +17,7 @@ location ~ ^/[\w-]+\.(js|css)$ {
 }
 
 # User profile page
-location ~* ^/users/[\w-]+/?$ {
+location ~* ^/users/[a-zA-Z0-9_\-.]+/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -26,7 +26,7 @@ location ~* ^/users/[\w-]+/?$ {
 }
 
 # User specific pages
-location ~* ^/users/[\w-]+/((collections|favorites|message)?)/?$ {
+location ~* ^/users/[a-zA-Z0-9_\-.]+/((collections|favorites|message)?)/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;

--- a/nginx-pfe-staging-redirects.conf
+++ b/nginx-pfe-staging-redirects.conf
@@ -17,7 +17,7 @@ location ~ ^/[\w-]+\.(js|css)$ {
 }
 
 # User profile page
-location ~* ^/users/[\w-]+/?$ {
+location ~* ^/users/[a-zA-Z0-9_\-.]+/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -26,7 +26,7 @@ location ~* ^/users/[\w-]+/?$ {
 }
 
 # User specific pages
-location ~* ^/users/[\w-]+/((collections|favorites|message)?)/?$ {
+location ~* ^/users/[a-zA-Z0-9_\-.]+/((collections|favorites|message)?)/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;


### PR DESCRIPTION
Removes the placeholder "word characters plus hyphen" regex and allows underscores, hyphens, periods to be matched by the `/users/` PFE redirect directives.