### PR TITLE
Consolidate redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD nginx.conf /etc/nginx/nginx.conf
 ADD nginx-redirects.conf /etc/nginx/redirects.conf
 ADD nginx-proxy.conf /etc/nginx/proxy.conf
 ADD nginx-proxy-security-headers.conf /etc/nginx/proxy-security-headers.conf
-ADD nginx-fem-project-redirects.conf /etc/nginx/fem-project-redirects.conf
+ADD nginx-project-redirects.conf /etc/nginx/project-redirects.conf
 ADD nginx-pfe-redirects.conf /etc/nginx/pfe-redirects.conf
 ADD nginx-pfe-staging-redirects.conf /etc/nginx/pfe-staging-redirects.conf
 ADD nginx-s3-proxy-headers.conf /etc/nginx/s3-proxy-headers.conf

--- a/nginx-project-redirects.conf
+++ b/nginx-project-redirects.conf
@@ -1,3 +1,39 @@
+# Redirects for renamed projects
+
+location ~* ^/projects/meredithspalmer/(cedar-creek-eyes-on-the-wild/?)(.*?)\/?$ {
+    return 301 /projects/forestis/$1$2$is_args$query_string;
+}
+
+location ~* ^/projects/karilint/the-cradle-of-mankind(/?)(.*?)\/?$ {
+    return 301 /projects/karilint/cradle-of-humanity$1$2$is_args$query_string;
+}
+
+location ~* ^/projects/cseidenstuecker/every-name-counts(/?)(.*?)\/?$ {
+    return 301 /projects/arolsen-archives/every-name-counts$1$2$is_args$query_string;
+}
+
+location ~* ^/projects/kevinesolberg/mapping-prejudice(/?)(.*?)\/?$ {
+    return 301 /projects/mappingprejudice/mapping-prejudice$1$2$is_args$query_string;
+}
+
+location ~* ^/projects/chiarasemenzin/maturity-of-baby-sounds(/?)(.*?)\/?$ {
+    return 301 /projects/laac-lscp/maturity-of-baby-sounds$1$2$is_args$query_string;
+}
+
+location ~* ^/projects/sarah-middle/voyages-in-time(/?)(.*?)\/?$ {
+    return 301 /projects/toolsofknowledge/voyages-in-time$1$2$is_args$query_string;
+}
+
+location ~* ^/projects/rsengar/pulsar-seekers(/?)(.*?)\/?$ {
+    return 301 /projects/rsengar/einstein-at-home-pulsar-seekers$1$2$is_args$query_string;
+}
+
+location ~* ^/projects/hughdickinson/superwasp-black-hole-hunters(/?)(.*?)\/?$ {
+    return 301 /projects/cobalt-lensing/black-hole-hunters$1$2$is_args$query_string;
+}
+
+# FEM project redirects
+
 location ~* ^/projects/(?:[\w-]*?/)?zookeeper/galaxy-zoo-weird-and-wonderful/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;

--- a/sites/frontend.preview.zooniverse.org.conf
+++ b/sites/frontend.preview.zooniverse.org.conf
@@ -3,7 +3,7 @@ server {
     set $fe_project_host "fe-project.preview.zooniverse.org";
 
     include /etc/nginx/ssl.default.conf;
-    include /etc/nginx/fem-project-redirects.conf;
+    include /etc/nginx/project-redirects.conf;
     include /etc/nginx/pfe-staging-redirects.conf;
     server_name frontend.preview.zooniverse.org;
 

--- a/sites/static-staging.zooniverse.org.conf
+++ b/sites/static-staging.zooniverse.org.conf
@@ -3,7 +3,7 @@ server {
     set $fe_project_host "fe-project.preview.zooniverse.org";
 
     include /etc/nginx/ssl.default.conf;
-    include /etc/nginx/fem-project-redirects.conf;
+    include /etc/nginx/project-redirects.conf;
     include /etc/nginx/pfe-staging-redirects.conf;
     server_name static-staging.zooniverse.org;
 

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -3,7 +3,7 @@ server {
     set $fe_project_host "fe-project.zooniverse.org";
 
     include /etc/nginx/ssl.default.conf;
-    include /etc/nginx/fem-project-redirects.conf;
+    include /etc/nginx/project-redirects.conf;
     include /etc/nginx/pfe-redirects.conf;
 
     server_name www.zooniverse.org;
@@ -74,38 +74,6 @@ server {
 
     location /contact {
         return 301 /about/contact;
-    }
-
-    location ~* ^/projects/meredithspalmer/(cedar-creek-eyes-on-the-wild/?)(.*?)\/?$ {
-        return 301 /projects/forestis/$1$2$is_args$query_string;
-    }
-
-    location ~* ^/projects/karilint/the-cradle-of-mankind(/?)(.*?)\/?$ {
-        return 301 /projects/karilint/cradle-of-humanity$1$2$is_args$query_string;
-    }
-
-    location ~* ^/projects/cseidenstuecker/every-name-counts(/?)(.*?)\/?$ {
-        return 301 /projects/arolsen-archives/every-name-counts$1$2$is_args$query_string;
-    }
-
-    location ~* ^/projects/kevinesolberg/mapping-prejudice(/?)(.*?)\/?$ {
-        return 301 /projects/mappingprejudice/mapping-prejudice$1$2$is_args$query_string;
-    }
-
-    location ~* ^/projects/chiarasemenzin/maturity-of-baby-sounds(/?)(.*?)\/?$ {
-        return 301 /projects/laac-lscp/maturity-of-baby-sounds$1$2$is_args$query_string;
-    }
-
-    location ~* ^/projects/sarah-middle/voyages-in-time(/?)(.*?)\/?$ {
-        return 301 /projects/toolsofknowledge/voyages-in-time$1$2$is_args$query_string;
-    }
-
-    location ~* ^/projects/rsengar/pulsar-seekers(/?)(.*?)\/?$ {
-        return 301 /projects/rsengar/einstein-at-home-pulsar-seekers$1$2$is_args$query_string;
-    }
-
-    location ~* ^/projects/hughdickinson/superwasp-black-hole-hunters(/?)(.*?)\/?$ {
-        return 301 /projects/cobalt-lensing/black-hole-hunters$1$2$is_args$query_string;
     }
 
     # Default to fe-root app


### PR DESCRIPTION
Because the `/projects` prefix matcher was being evaluated in `pfe-redirects.conf`, the renamed project 301s further down in www.zooniverse.org.conf weren't getting checked. This moves them into the file with the FEM project redirects, which is included first, and renames it for clarity. This also allows them to work on frontend.preview and static-staging.