### PR TITLE
Add proxy rule for robots.txt

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -24,6 +24,13 @@ server {
     rewrite ^/lab-best-practices/the-long-haul$ https://help.zooniverse.org/best-practices/3-long-haul permanent;
     rewrite ^/lab-best-practices/resources$ https://help.zooniverse.org/best-practices/4-resources permanent;
 
+    location /robots.txt {
+        resolver 1.1.1.1;
+        proxy_pass https://static.zooniverse.org/robots.txt;
+
+        include /etc/nginx/az-proxy-headers.conf;
+    }
+
     location /password/reset {
         return 301 /reset-password;
     }

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -26,7 +26,7 @@ server {
 
     location /robots.txt {
         resolver 1.1.1.1;
-        proxy_pass https://static.zooniverse.org/robots.txt;
+        proxy_pass https://static.zooniverse.org/www.zooniverse.org/robots.txt;
 
         include /etc/nginx/az-proxy-headers.conf;
     }


### PR DESCRIPTION
Proxy www.zooniverse.org/robots.txt to static.zooniverse.org/robots.txt. This allows the www robots.txt to be permissive, while the robots.txt served by the FEM apps can remain restrictive to prevent crawling of other subdomains.