### PR TITLE
Codify new aggregation deploy scheme

### DIFF
--- a/kubernetes/ingress/zooniverse.org.yaml
+++ b/kubernetes/ingress/zooniverse.org.yaml
@@ -110,6 +110,16 @@ spec:
             name: http-frontend
             port:
               number: 80
+  - host: aggregation-staging.zooniverse.org
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: aggregation-staging-app
+            port:
+              number: 80
   - host: aggregation-caesar.zooniverse.org
     http:
       paths:
@@ -117,7 +127,7 @@ spec:
         path: /
         backend:
           service:
-            name: aggregation-caesar
+            name: aggregation-production-app
             port:
               number: 80
   - host: caesar-staging.zooniverse.org


### PR DESCRIPTION
I'm modifying the aggregation deploy scheme to be more in line with zooniverse standards, with `-production-app` and `-staging-app` services. Updates the zoo ingress to route the relevant domains to those services. Corresponding work on aggregation repo is already finished, and a follow up from this will be to manually scale down and remove the `aggregation-caesar` deployment.