### PR TITLE
Enable full site downtime

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -3,8 +3,10 @@ server {
     set $fe_project_host "fe-project.zooniverse.org";
 
     include /etc/nginx/ssl.default.conf;
-    include /etc/nginx/project-redirects.conf;
-    include /etc/nginx/pfe-redirects.conf;
+
+    # DOWNTIME, let the / below catch everything
+    # include /etc/nginx/project-redirects.conf;
+    # include /etc/nginx/pfe-redirects.conf;
 
     server_name www.zooniverse.org;
 
@@ -84,11 +86,23 @@ server {
     }
 
     # Default to fe-root app
-    location / {
-        resolver 1.1.1.1;
-        proxy_pass "https://fe-root.zooniverse.org";
-        proxy_set_header Host fe-root.zooniverse.org;
+    # SITE DISABLED
+    # location / {
+    #     resolver 1.1.1.1;
+    #     proxy_pass "https://fe-root.zooniverse.org";
+    #     proxy_set_header Host fe-root.zooniverse.org;
 
-        include /etc/nginx/proxy-security-headers.conf;
+    #     include /etc/nginx/proxy-security-headers.conf;
+    # }
+
+    # DOWNTIME ENABLED
+    set $status_uri "https://zooniverse-359.freshstatus.io";
+    location / {
+        # Put the URL in a variable to force re-resolution of the DNS name
+        # Otherwise nginx will cache it indefinitely and it'll break if IPs change
+        resolver 1.1.1.1;
+        proxy_pass $status_uri;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
 }


### PR DESCRIPTION
Next week's database migrations mean that the Panoptes, Caesar, and Talk APIs will all be down at once for a short period.

When this PR deploys to production, the entire www subdomain of zooniverse.org will redirect to Freshstatus. Includes for configs that contain redirects and other directives have been commented out and `/` will proxy to zooniverse-359.freshstatus.io. Talk is included in this behavior. Caesar will just 500, which is ok with me. I left everything else (star dots, frontend.preview, etc) since those aren't used outside of the org and can be used internally to test functionality against the production APIs. 

When the APIs are restored, this PR can be reverted and production deployed to restore normal operation. I tested this via curl and it makes sense to me, but please look this over and let me know if I missed anything or if this should include other subdomains. I plan to deploy this when the maintenance period begins on the 20th. 