### PR TITLE
Update spacewarps.org redirect for Euclid

### DIFF
--- a/sites/spacewarps.org.conf
+++ b/sites/spacewarps.org.conf
@@ -7,7 +7,7 @@ server {
     }
 
     location / {
-        return 301 https://www.zooniverse.org/projects/aprajita/space-warps-des-vision-transformer;
+        return 301 https://www.zooniverse.org/projects/aprajita/space-warps-esa-euclid;
     }
 }
 


### PR DESCRIPTION
In support of the launch for [Space Warps - ESA Euclid](https://www.zooniverse.org/projects/aprajita/space-warps-esa-euclid), this PR updates the redirect for the spacewarps.org domain.