### PR TITLE
Add JuDE redirect to JVH project page

### DIFF
--- a/nginx-redirects.conf
+++ b/nginx-redirects.conf
@@ -825,3 +825,9 @@ server {
     server_name www.supernovahunters.org supernovahunters.org;
     return 301 https://www.zooniverse.org/projects/dwright04/supernova-hunters;
 }
+
+server {
+    include /etc/nginx/ssl.default.conf;
+    server_name jude.zooniverse.org;
+    return 301 https://www.zooniverse.org/projects/ramanakumars/jovian-vortex-hunter;
+}


### PR DESCRIPTION
As confirmed by Ramana, JuDE is likely out of service for some time, and is not likely to return in the same form (externally-hosted on DigitalOcean).  Therefore, we're pointing the jude.zooniverse.org subdomain at the static server (rather than a specific DigitalOcean IP where the old app was hosted) and redirecting back to the Jovian Vortex Hunter project page (https://www.zooniverse.org/projects/ramanakumars/jovian-vortex-hunter).