### PR TITLE
Enable full site downtime redirect

### DIFF
--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -3,8 +3,10 @@ server {
     set $fe_project_host "fe-project.zooniverse.org";
 
     include /etc/nginx/ssl.default.conf;
-    include /etc/nginx/project-redirects.conf;
-    include /etc/nginx/pfe-redirects.conf;
+
+    # DOWNTIME, let the / below catch everything
+    # include /etc/nginx/project-redirects.conf;
+    # include /etc/nginx/pfe-redirects.conf;
 
     server_name www.zooniverse.org;
 
@@ -84,11 +86,17 @@ server {
     }
 
     # Default to fe-root app
-    location / {
-        resolver 1.1.1.1;
-        proxy_pass "https://fe-root.zooniverse.org";
-        proxy_set_header Host fe-root.zooniverse.org;
+    # SITE DISABLED
+    # location / {
+    #     resolver 1.1.1.1;
+    #     proxy_pass "https://fe-root.zooniverse.org";
+    #     proxy_set_header Host fe-root.zooniverse.org;
 
-        include /etc/nginx/proxy-security-headers.conf;
+    #     include /etc/nginx/proxy-security-headers.conf;
+    # }
+
+    # DOWNTIME REDIRECT
+    location / {
+        return 302 "https://status.zooniverse.org";
     }
 }


### PR DESCRIPTION
Related to Feb 2025 DB downtime incident and subsequent DB migration, enable temporary redirect (via 302) to status.zooniverse.org