### PR TITLE
Add FEM redirect for Woodpecker learning

### DIFF
--- a/nginx-project-redirects.conf
+++ b/nginx-project-redirects.conf
@@ -481,3 +481,11 @@ location ~* ^/projects/(?:[\w-]*?/)?cmcbrain/axonal-pathfinders/?(?:(classify|ab
 
     include /etc/nginx/proxy-security-headers.conf;
 }
+
+location ~* ^/projects/(?:[\w-]*?/)?pmason/woodpecker-cavity-cam-learning/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    resolver 1.1.1.1;
+    proxy_pass $fe_project_uri;
+    proxy_set_header Host $fe_project_host;
+
+    include /etc/nginx/proxy-security-headers.conf;
+}


### PR DESCRIPTION
FEM redirect for pmason/woodpecker-cavity-cam-learning (Project 21409). Requested via contact@.

PFE PR: https://github.com/zooniverse/Panoptes-Front-End/pull/7286
Staging branch URL: https://pr-7286.pfe-preview.zooniverse.org/
Staging URL for Project: https://pr-7286.pfe-preview.zooniverse.org/projects/pmason/woodpecker-cavity-cam-learning
Target Link: https://www.zooniverse.org/projects/pmason/woodpecker-cavity-cam-learning
Project Lab Link: https://www.zooniverse.org/lab/21409