### PR TITLE
Allow SVGs via proxy rewrites on trusted domains

### DIFF
--- a/nginx-pfe-redirects.conf
+++ b/nginx-pfe-redirects.conf
@@ -18,7 +18,7 @@ location ~ ^/[\w-]+\.(js|css)$ {
 
 # User profile page
 location ~* ^/users/[a-zA-Z0-9_\-.]+/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
@@ -27,7 +27,7 @@ location ~* ^/users/[a-zA-Z0-9_\-.]+/?$ {
 
 # User specific pages
 location ~* ^/users/[a-zA-Z0-9_\-.]+/((collections|favorites|message)?)/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
@@ -37,7 +37,7 @@ location ~* ^/users/[a-zA-Z0-9_\-.]+/((collections|favorites|message)?)/?$ {
 # Default: /project/* to PFE
 # Can be overridden by directives in nginx-project-redirects.conf
 location ~* ^/projects {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
@@ -46,7 +46,7 @@ location ~* ^/projects {
 
 # Most of the main PFE redirects
 location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy) {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
@@ -57,7 +57,7 @@ location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|
 # so needs it's own location block to handle the form submission POST
 # and the GET page loading (PFE routing handles the path)
 location /unsubscribe {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     if ($request_method ~ ^(GET|HEAD)$) {

--- a/nginx-pfe-staging-redirects.conf
+++ b/nginx-pfe-staging-redirects.conf
@@ -18,7 +18,7 @@ location ~ ^/[\w-]+\.(js|css)$ {
 
 # User profile page
 location ~* ^/users/[a-zA-Z0-9_\-.]+/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
@@ -27,7 +27,7 @@ location ~* ^/users/[a-zA-Z0-9_\-.]+/?$ {
 
 # User specific pages
 location ~* ^/users/[a-zA-Z0-9_\-.]+/((collections|favorites|message)?)/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
@@ -46,7 +46,7 @@ location ~* ^/projects/(?:[\w-]*?/)?brooke/i-fancy-cats/?(?:(classify|about)(?:/
 # Default: /project/* to PFE
 # Can be overridden by directives in nginx-project-redirects.conf
 location ~* ^/projects {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
@@ -55,7 +55,7 @@ location ~* ^/projects {
 
 # Most of the main PFE redirects
 location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy) {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
@@ -66,7 +66,7 @@ location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|
 # so needs it's own location block to handle the form submission POST
 # and the GET page loading (PFE routing handles the path)
 location /unsubscribe {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
     if ($request_method ~ ^(GET|HEAD)$) {

--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -1,5 +1,5 @@
 location / {
-    rewrite (?i)\.(jp(e)?g|gif|png|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/$host$request_uri;
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/$host$request_uri;
 
     resolver 8.8.8.8;
     proxy_pass             https://zooniversestatic.z13.web.core.windows.net/$host$request_uri;

--- a/sites/lab.zooniverse.org.conf
+++ b/sites/lab.zooniverse.org.conf
@@ -5,7 +5,7 @@ server {
     location / {
         resolver 8.8.8.8;
 
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/lab.zooniverse.org$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/lab.zooniverse.org$request_uri;
 
         include /etc/nginx/az-proxy-headers.conf;
 

--- a/sites/star.lab-preview.zooniverse.org.conf
+++ b/sites/star.lab-preview.zooniverse.org.conf
@@ -3,7 +3,7 @@ server {
     server_name "~^(?P<subdomain>.*)\.lab-preview\.zooniverse\.org$";
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/pfe-lab/$subdomain$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/pfe-lab/$subdomain$request_uri;
 
         resolver 8.8.8.8;
         proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/pfe-lab/$subdomain/;
@@ -16,7 +16,7 @@ server {
     server_name lab-preview.zooniverse.org;
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/pfe-lab$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/pfe-lab$request_uri;
 
         resolver 8.8.8.8;
 

--- a/sites/star.pfe-preview.zooniverse.org.conf
+++ b/sites/star.pfe-preview.zooniverse.org.conf
@@ -3,7 +3,7 @@ server {
     server_name "~^(?P<subdomain>.*)\.pfe-preview\.zooniverse\.org$";
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/panoptes-front-end/$subdomain$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/panoptes-front-end/$subdomain$request_uri;
 
         resolver 8.8.8.8;
         proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/panoptes-front-end/$subdomain/;
@@ -17,7 +17,7 @@ server {
     server_name pfe-preview.zooniverse.org;
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/panoptes-front-end$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/panoptes-front-end$request_uri;
 
         resolver 8.8.8.8;
 

--- a/sites/star.preview.zooniverse.org.conf
+++ b/sites/star.preview.zooniverse.org.conf
@@ -3,7 +3,7 @@ server {
     server_name "~^(?P<subdomain>.*)\.preview\.zooniverse\.org$";
 
     location / {
-        rewrite (?i)\.(jp(e)?g|gif|png|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/$subdomain$request_uri;
+        rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip|js|css)$ https://static.zooniverse.org/preview.zooniverse.org/$subdomain$request_uri;
 
         resolver 8.8.8.8;
         proxy_pass             https://zooniversestatic.z13.web.core.windows.net/preview.zooniverse.org/$subdomain$request_uri;


### PR DESCRIPTION
Adds `svg` to the list of static assets in the standard rewrite directive for trusted domains. We avoid rendering unsanitized user uploaded SVGs for security reasons. But these domains only host assets managed internally, and svgs can provide benefits over other file types and should be allowed. The following domains are affected:

- [www.zooniverse.org](http://www.zooniverse.org/)
- [fe-project.preview.zooniverse.org](http://fe-project.preview.zooniverse.org/)
- [fe-project.zooniverse.org](http://fe-project.zooniverse.org/)
- [lab.zooniverse.org](http://lab.zooniverse.org/)
- *.lab-preview.zooniverse.org / [preview.zooniverse.org/pfe-lab](http://preview.zooniverse.org/pfe-lab)
- *.pfe-preview.zooniverse.org / [preview.zooniverse.org/panoptes-front-end](http://preview.zooniverse.org/panoptes-front-end)
- *.preview.zooniverse.org