### PR TITLE
PFE routing: add Rubin landing page at www.zooniverse.org/rubin

### DIFF
--- a/nginx-pfe-redirects.conf
+++ b/nginx-pfe-redirects.conf
@@ -45,7 +45,7 @@ location ~* ^/projects {
 }
 
 # Most of the main PFE redirects
-location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy) {
+location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy|rubin) {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;

--- a/nginx-pfe-staging-redirects.conf
+++ b/nginx-pfe-staging-redirects.conf
@@ -54,7 +54,7 @@ location ~* ^/projects {
 }
 
 # Most of the main PFE redirects
-location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy) {
+location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy|rubin) {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;


### PR DESCRIPTION
## PR Overview

Related: zooniverse/Panoptes-Front-End#7310

The intent of this PR is to enable the Rubin landing page, by routing the `/rubin` path to PFE.

- i.e. http://www.zooniverse.org/rubin (which is currently an FEM 404 page) should let users see https://master.pfe-preview.zooniverse.org/rubin (a PFE page)

### Status

Ready for review, and please let me know if I'm doing anything wrong with this routing sorcery.