### PR TITLE
Update /rubin redirect to organization page

### DIFF
--- a/nginx-pfe-redirects.conf
+++ b/nginx-pfe-redirects.conf
@@ -45,7 +45,7 @@ location ~* ^/projects {
 }
 
 # Most of the main PFE redirects
-location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy|rubin) {
+location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy) {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;

--- a/nginx-pfe-staging-redirects.conf
+++ b/nginx-pfe-staging-redirects.conf
@@ -54,7 +54,7 @@ location ~* ^/projects {
 }
 
 # Most of the main PFE redirects
-location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy|rubin) {
+location ~* ^/(organizations|collections|favorites|talk|notifications|inbox|lab|admin|accounts|reset-password|settings|privacy|security|youth_privacy) {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;

--- a/sites/www.zooniverse.org.conf
+++ b/sites/www.zooniverse.org.conf
@@ -83,6 +83,10 @@ server {
         return 301 /about/contact;
     }
 
+    location /rubin {
+        return 302 https://www.zooniverse.org/organizations/rubinepo/rubin-observatory;
+    }
+
     # Default to fe-root app
     location / {
         resolver 1.1.1.1;


### PR DESCRIPTION
Previously, `|rubin` was added to the PFE regex to catch `zooniverse.org/rubin` and redirect to PFE to display the Rubin-specific landing page.

This PR updates the www.zooniverse.org.conf nginx file with a new entry for `location /rubin` that redirects to the organization page https://www.zooniverse.org/organizations/rubinepo/rubin-observatory. I used 302 (temporary) instead of a  301 (permanent) redirect in case this gets updated later. 

Tested with curl locally.