### PR TITLE
Change HCO test project name in FEM redirect

### DIFF
--- a/nginx-project-redirects.conf
+++ b/nginx-project-redirects.conf
@@ -202,7 +202,7 @@ location ~* ^/projects/(?:[\w-]*?/)?fulsdavid/the-daily-minor-planet/?(?:(classi
     include /etc/nginx/proxy-security-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?blicksam/human-machine-collaborative-transcription/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?blicksam/human-machine-transcription-sandbox/?(?:(classify|about)(?:/.+?)?)?/?$ {
     resolver 1.1.1.1;
     proxy_pass $fe_project_uri;
     proxy_set_header Host $fe_project_host;


### PR DESCRIPTION
Changes the HCO test project name from 

`blicksam/human-machine-collaborative-transcription`

to

`blicksam/human-machine-transcription-sandbox`
