### PR TITLE
Update to nginx version 1.29 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zooniverse/nginx:1.20
+FROM ghcr.io/zooniverse/docker-nginx:1.29
 
 RUN mkdir -p /nginx-cache/  &&  touch /etc/nginx-deny.conf
 


### PR DESCRIPTION
The zooniverse/docker-nginx repo has been updated to build and push images to GHCR. There is now a new image, tagged 1.29, that builds ~1.29.x images weekly. This PR updates the static proxy to use this new image, and thus the new version of nginx. It's locked to 1.29, the mainline branch.