### PR TITLE
Pass user IPs through to apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM ghcr.io/zooniverse/docker-nginx:1.29
 
+RUN apt-get update && apt-get install -y jq
+
 RUN mkdir -p /nginx-cache/  &&  touch /etc/nginx-deny.conf
 
-ADD nginx.conf /etc/nginx/nginx.conf
+COPY generate-nginx-config.sh /usr/local/bin/
+COPY nginx.conf.template /tmp/
+RUN chmod +x /usr/local/bin/generate-nginx-config.sh && /usr/local/bin/generate-nginx-config.sh
+RUN rm -f /usr/local/bin/generate-nginx-config.sh /tmp/nginx.conf.template
+
 ADD nginx-redirects.conf /etc/nginx/redirects.conf
 ADD nginx-proxy.conf /etc/nginx/proxy.conf
 ADD nginx-proxy-security-headers.conf /etc/nginx/proxy-security-headers.conf

--- a/generate-nginx-config.sh
+++ b/generate-nginx-config.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+AZURE_IPS_URL="https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519"
+ACTUAL_URL=$(curl -sL "$AZURE_IPS_URL" | grep -Eo 'https://download\.microsoft\.com/download/[^"]*\.json' | head -1)
+
+if [ -z "$ACTUAL_URL" ]; then
+    echo "Error: Could not find Azure IP ranges download URL"
+    exit 1
+fi
+
+curl -s "$ACTUAL_URL" | jq -r '
+.values[] |
+select(.name | test("AzureFrontDoor.Backend"; "i")) |
+.properties.addressPrefixes[]' | sort -u > azure_frontdoor_ips.txt
+
+IP_COUNT=$(wc -l < ./azure_frontdoor_ips.txt)
+echo "Retrieved $IP_COUNT Azure Front Door IP ranges"
+
+while read ip; do
+    echo "    set_real_ip_from $ip;"
+done < azure_frontdoor_ips.txt > azure_directives.txt
+
+sed -e '/{{AZURE_IPS}}/ {
+    r azure_directives.txt
+    d
+}' /tmp/nginx.conf.template > /etc/nginx/nginx.conf

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -59,8 +59,18 @@ http {
     # Virtual Host Configs
     ##
 
+    ##
+    # Azure Frontdoor IPs
+    ##
+
+    {{AZURE_IPS}}
+
     real_ip_header X-Forwarded-For;
-    set_real_ip_from 172.29.0.0/16;
+    real_ip_recursive on;
+
+    # Forward user ip on in header
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     proxy_cache_path  /nginx-cache/  levels=1:2 keys_zone=STATIC:10m inactive=24h  max_size=1g;
     server {


### PR DESCRIPTION
Currently, all traffic behind the Azure Front Door CDN cannot distinguish the real user remote IP from the FD IPs also included in a proxied request's headers. This PR pulls a Microsoft-generated list of Azure Front Door IPs and sets each of them with the `set_real_ip_from`. This, along with `real_ip_recursive`, will allow the proxy to determine the original client address. This remaining address is then passed on via the `X-Real-IP` header to the rest of cluster and to individual apps.

Unlike AWS, there isn't just a json file to download. There's a *site*, and that site has a download link to a file that changes it's name when it updates, hence the annoying bit of curling and parsing in the beginning. The actual IPs then replace the placeholder in the template file and so they'll update whenever this image is rebuilt.

I'll be updating the sidecar nginx containers for apps that use them to remove some of the unnecessary directives in them, but this should start working as soon as it deploys. Once reviewed, I'll merge and check out the staging server and see if those logs change.