### PR TITLE
Include internal IPs in set_real_ip_from

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -65,10 +65,19 @@ http {
 
     {{AZURE_IPS}}
 
+    ##
+    # Azure internal IPs
+    ##
+
+    set_real_ip_from 10.0.0.0/8;
+
+    ##
+    # Forward client IP on in header
+    ##
+
     real_ip_header X-Forwarded-For;
     real_ip_recursive on;
 
-    # Forward user ip on in header
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 


### PR DESCRIPTION
The AKS load balancer sits between the Front Door and the static proxy. Include the internal AKS IPs in the list of `set_real_ip_from` directives.