### PR TITLE
Remove audio only projects from special redirects

### DIFF
--- a/nginx-special-redirects.conf
+++ b/nginx-special-redirects.conf
@@ -398,6 +398,14 @@ location ~* ^/projects/(?:[\w-]*?/)?tingard/galaxy-builder/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
+location ~* ^/projects/(?:[\w-]*?/)?uw-leap/tots-and-tunes/?(?:(classify|about)(?:/.+?)?)?/?$ {
+    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
+
+    resolver 1.1.1.1;
+    proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
+    include /etc/nginx/az-proxy-headers.conf;
+}
+
 location ~* ^/projects/(?:[\w-]*?/)?watchablewildlife/nebraska-wildlife-watch/?(?:(classify|about)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 

--- a/nginx-special-redirects.conf
+++ b/nginx-special-redirects.conf
@@ -14,14 +14,6 @@ location ~* ^/projects/(?:[\w-]*?/)?alicemead/sudan-road-access-logistics-cluste
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?annelistens/ocean-voices/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
-
-    resolver 1.1.1.1;
-    proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
-    include /etc/nginx/az-proxy-headers.conf;
-}
-
 location ~* ^/projects/(?:[\w-]*?/)?aprajita/space-warps-des-vision-transformer/?(?:(classify|about)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
@@ -47,14 +39,6 @@ location ~* ^/projects/(?:[\w-]*?/)?astorino/sovraimpressioni/?(?:(classify|abou
 }
 
 location ~* ^/projects/(?:[\w-]*?/)?astro-lab-ncmns/spiral-graph/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
-
-    resolver 1.1.1.1;
-    proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
-    include /etc/nginx/az-proxy-headers.conf;
-}
-
-location ~* ^/projects/(?:[\w-]*?/)?cblume27/rhythms-of-the-night/?(?:(classify|about)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -158,14 +142,6 @@ location ~* ^/projects/(?:[\w-]*?/)?judaicadh/scribes-of-the-cairo-geniza/?(?:(c
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?laac-lscp/maturity-of-baby-sounds/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
-
-    resolver 1.1.1.1;
-    proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
-    include /etc/nginx/az-proxy-headers.conf;
-}
-
 location ~* ^/projects/(?:[\w-]*?/)?laaczooniverse/what-do-babies-say/?(?:(classify|about)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
@@ -175,14 +151,6 @@ location ~* ^/projects/(?:[\w-]*?/)?laaczooniverse/what-do-babies-say/?(?:(class
 }
 
 location ~* ^/projects/(?:[\w-]*?/)?lcjohnso/lcj-pfe-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
-
-    resolver 1.1.1.1;
-    proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
-    include /etc/nginx/az-proxy-headers.conf;
-}
-
-location ~* ^/projects/(?:[\w-]*?/)?library-of-congress/transcribe-american-dialect-recordings/?(?:(classify|about)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -350,22 +318,6 @@ location ~* ^/projects/(?:[\w-]*?/)?nora-dot-eisner/planet-hunters-tess-mobile/?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ollibruuh/bird-find/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
-
-    resolver 1.1.1.1;
-    proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
-    include /etc/nginx/az-proxy-headers.conf;
-}
-
-location ~* ^/projects/(?:[\w-]*?/)?ollibruuh/frog-find/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
-
-    resolver 1.1.1.1;
-    proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
-    include /etc/nginx/az-proxy-headers.conf;
-}
-
 location ~* ^/projects/(?:[\w-]*?/)?panettafordham/shadows-on-stone-identifying-sing-sings-incarcerated/?(?:(classify|about)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
@@ -446,14 +398,6 @@ location ~* ^/projects/(?:[\w-]*?/)?tingard/galaxy-builder/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?uw-leap/tots-and-tunes/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
-
-    resolver 1.1.1.1;
-    proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
-    include /etc/nginx/az-proxy-headers.conf;
-}
-
 location ~* ^/projects/(?:[\w-]*?/)?watchablewildlife/nebraska-wildlife-watch/?(?:(classify|about)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
@@ -463,14 +407,6 @@ location ~* ^/projects/(?:[\w-]*?/)?watchablewildlife/nebraska-wildlife-watch/?(
 }
 
 location ~* ^/projects/(?:[\w-]*?/)?wildcam/wildcam-darien/?(?:(classify|about)(?:/.+?)?)?/?$ {
-    rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
-
-    resolver 1.1.1.1;
-    proxy_pass https://zooniversestatic.z13.web.core.windows.net/$proxy_path/;
-    include /etc/nginx/az-proxy-headers.conf;
-}
-
-location ~* ^/projects/(?:[\w-]*?/)?wingkitty/filk-archive/?(?:(classify|about)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;


### PR DESCRIPTION
Removes audio-only projects from the special redrects conf file. This feature is now enabled in FEM and these projects are migrating.

PFE PR: https://github.com/zooniverse/Panoptes-Front-End/pull/7469

