### PR TITLE
Point legacy apps to correct services

### DIFF
--- a/kubernetes/ingress/galaxyzooforum.org.yaml
+++ b/kubernetes/ingress/galaxyzooforum.org.yaml
@@ -24,7 +24,7 @@ spec:
     - match: Host(`galaxyzooforum.org`) || HostRegexp(`^.+\.galaxyzooforum\.org$`)
       kind: Rule
       services:
-        - name: http-frontend
+        - name: php-nginx
           port: 80
   tls:
     secretName: galaxyzooforum-org-tls

--- a/kubernetes/ingress/moonzoo.org.yaml
+++ b/kubernetes/ingress/moonzoo.org.yaml
@@ -24,7 +24,7 @@ spec:
     - match: Host(`moonzoo.org`) || HostRegexp(`^.+\.moonzoo\.org$`)
       kind: Rule
       services:
-        - name: http-frontend
+        - name: php-nginx
           port: 80
   tls:
     secretName: moonzoo-org-tls

--- a/kubernetes/ingress/oldweather.org.yaml
+++ b/kubernetes/ingress/oldweather.org.yaml
@@ -24,7 +24,7 @@ spec:
     - match: Host(`oldweather.org`) || HostRegexp(`^.+\.oldweather\.org$`)
       kind: Rule
       services:
-        - name: http-frontend
+        - name: php-nginx
           port: 80
   tls:
     secretName: oldweather-org-tls

--- a/kubernetes/ingress/solarstormwatch.com.yaml
+++ b/kubernetes/ingress/solarstormwatch.com.yaml
@@ -24,7 +24,7 @@ spec:
     - match: Host(`solarstormwatch.com`) || HostRegexp(`^.+\.solarstormwatch\.com$`)
       kind: Rule
       services:
-        - name: http-frontend
+        - name: php-nginx
           port: 80
   tls:
     secretName: solarstormwatch-com-tls


### PR DESCRIPTION
These services (PHP forums, mostly) are still running as legacy apps. These updated ingresses point the hosts at the correct shared service.

These changes have already been tested and applied, this PR is a no-op.