### PR TITLE
Remove PFE redirect for project stats pages

### DIFF
--- a/nginx-pfe-redirects.conf
+++ b/nginx-pfe-redirects.conf
@@ -26,7 +26,7 @@ location ~* ^/users/[a-zA-Z0-9_\-.]+/((collections|favorites|message)?)/?$ {
 }
 
 # Remaining PFE-hosted /projects/ subpaths
-location ~ ^/projects/([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+)/(collections|recents|talk|favorites|stats|notifications|users)(/|$) {
+location ~ ^/projects/([a-zA-Z0-9_.-]+)/([a-zA-Z0-9_.-]+)/(collections|recents|talk|favorites|notifications|users)(/|$) {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;

--- a/nginx-private-project-redirects.conf
+++ b/nginx-private-project-redirects.conf
@@ -1,4 +1,4 @@
-location ~* ^/projects/(?:[\w-]*?/)?a-alam/classification-of-complex-radio-sources/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?a-alam/classification-of-complex-radio-sources/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -6,7 +6,7 @@ location ~* ^/projects/(?:[\w-]*?/)?a-alam/classification-of-complex-radio-sourc
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?a-gordon/galaxy-tidal-feature-classifications/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?a-gordon/galaxy-tidal-feature-classifications/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -14,7 +14,7 @@ location ~* ^/projects/(?:[\w-]*?/)?a-gordon/galaxy-tidal-feature-classification
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ahendy/reading-the-fossil-record/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ahendy/reading-the-fossil-record/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -22,7 +22,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ahendy/reading-the-fossil-record/?(?:(classi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ahsiang/auto-foram-batch-2-plus-3-for-anieke/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ahsiang/auto-foram-batch-2-plus-3-for-anieke/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -30,7 +30,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ahsiang/auto-foram-batch-2-plus-3-for-anieke
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ahsiang/auto-foram-species/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ahsiang/auto-foram-species/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -38,7 +38,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ahsiang/auto-foram-species/?(?:(classify|abo
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?alevi98/african-american-civil-war-soldiers-error-correction/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?alevi98/african-american-civil-war-soldiers-error-correction/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -46,7 +46,7 @@ location ~* ^/projects/(?:[\w-]*?/)?alevi98/african-american-civil-war-soldiers-
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?alex-andersson/private-radio-transients-r-b-classifier-11-03-2021-14-12-41/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?alex-andersson/private-radio-transients-r-b-classifier-11-03-2021-14-12-41/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -54,7 +54,7 @@ location ~* ^/projects/(?:[\w-]*?/)?alex-andersson/private-radio-transients-r-b-
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?alexsokolowska/rockfalls-cerberus-fossae/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?alexsokolowska/rockfalls-cerberus-fossae/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -62,7 +62,7 @@ location ~* ^/projects/(?:[\w-]*?/)?alexsokolowska/rockfalls-cerberus-fossae/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?amandinedd/delve-deep-madcash/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?amandinedd/delve-deep-madcash/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -70,7 +70,7 @@ location ~* ^/projects/(?:[\w-]*?/)?amandinedd/delve-deep-madcash/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?amarch/klassifikatsiia-b-ps-baldzhiei-na-osnovie-nalichiia-kh-struktur/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?amarch/klassifikatsiia-b-ps-baldzhiei-na-osnovie-nalichiia-kh-struktur/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -78,7 +78,7 @@ location ~* ^/projects/(?:[\w-]*?/)?amarch/klassifikatsiia-b-ps-baldzhiei-na-osn
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ameirshaa/nuclear-track-detector-scans-at-cern/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ameirshaa/nuclear-track-detector-scans-at-cern/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -86,7 +86,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ameirshaa/nuclear-track-detector-scans-at-ce
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ameliafm612/sami-bars/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ameliafm612/sami-bars/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -94,7 +94,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ameliafm612/sami-bars/?(?:(classify|about)(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ans-dot-v/getuigenissen-brugge/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ans-dot-v/getuigenissen-brugge/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -102,7 +102,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ans-dot-v/getuigenissen-brugge/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-4/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-4/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -110,7 +110,7 @@ location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-4/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-5/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-5/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -118,7 +118,7 @@ location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-5/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-6/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-6/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -126,7 +126,7 @@ location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-6/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-7/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-7/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -134,7 +134,7 @@ location ~* ^/projects/(?:[\w-]*?/)?apapak/detecting-marine-litter-v-7/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?apapak/xampelia/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?apapak/xampelia/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -142,7 +142,7 @@ location ~* ^/projects/(?:[\w-]*?/)?apapak/xampelia/?(?:(classify|about)(?:/.+?)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?aprajita/swdemo/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?aprajita/swdemo/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -150,7 +150,7 @@ location ~* ^/projects/(?:[\w-]*?/)?aprajita/swdemo/?(?:(classify|about)(?:/.+?)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?arioeira/the-green-dots-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?arioeira/the-green-dots-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -158,7 +158,7 @@ location ~* ^/projects/(?:[\w-]*?/)?arioeira/the-green-dots-project/?(?:(classif
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/0-dot-5-oxia-candidates/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/0-dot-5-oxia-candidates/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -166,7 +166,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/0-dot-5-oxia-candidates/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/0-dot-8-rockfall-candidates/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/0-dot-8-rockfall-candidates/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -174,7 +174,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/0-dot-8-rockfall-candidates/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/ejecta-candidates/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/ejecta-candidates/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -182,7 +182,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/ejecta-candidates/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/oxia-0-dot-6-candidates-excluded-most-overlap/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/oxia-0-dot-6-candidates-excluded-most-overlap/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -190,7 +190,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/oxia-0-dot-6-candidates-exclude
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/rockfall-shadows/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/rockfall-shadows/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -198,7 +198,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/rockfall-shadows/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/rockfalls-from-urls/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/rockfalls-from-urls/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -206,7 +206,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ariyanabonab/rockfalls-from-urls/?(?:(classi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?arya75/affirmative-action-annotation/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?arya75/affirmative-action-annotation/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -214,7 +214,7 @@ location ~* ^/projects/(?:[\w-]*?/)?arya75/affirmative-action-annotation/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?aschig/classifying-lung-nodules/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?aschig/classifying-lung-nodules/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -222,7 +222,7 @@ location ~* ^/projects/(?:[\w-]*?/)?aschig/classifying-lung-nodules/?(?:(classif
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?aschig/ztf-astreaks/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?aschig/ztf-astreaks/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -230,7 +230,7 @@ location ~* ^/projects/(?:[\w-]*?/)?aschig/ztf-astreaks/?(?:(classify|about)(?:/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?astellez/tellez-css/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?astellez/tellez-css/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -238,7 +238,7 @@ location ~* ^/projects/(?:[\w-]*?/)?astellez/tellez-css/?(?:(classify|about)(?:/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?astopy/bhh-vetting/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?astopy/bhh-vetting/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -246,7 +246,7 @@ location ~* ^/projects/(?:[\w-]*?/)?astopy/bhh-vetting/?(?:(classify|about)(?:/.
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?astopy/superwasp-miras/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?astopy/superwasp-miras/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -254,7 +254,7 @@ location ~* ^/projects/(?:[\w-]*?/)?astopy/superwasp-miras/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?astrohayley/ceers-merger-verification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?astrohayley/ceers-merger-verification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -262,7 +262,7 @@ location ~* ^/projects/(?:[\w-]*?/)?astrohayley/ceers-merger-verification/?(?:(c
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?aucklandmuseum/heraldic-beasts-and-where-to-find-them/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?aucklandmuseum/heraldic-beasts-and-where-to-find-them/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -270,7 +270,7 @@ location ~* ^/projects/(?:[\w-]*?/)?aucklandmuseum/heraldic-beasts-and-where-to-
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?bathstm/stm-image-sorting/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?bathstm/stm-image-sorting/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -278,7 +278,7 @@ location ~* ^/projects/(?:[\w-]*?/)?bathstm/stm-image-sorting/?(?:(classify|abou
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?bessest/lifeplan/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?bessest/lifeplan/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -286,7 +286,7 @@ location ~* ^/projects/(?:[\w-]*?/)?bessest/lifeplan/?(?:(classify|about)(?:/.+?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?bgorges/classify-robot-auto-detected-images/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?bgorges/classify-robot-auto-detected-images/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -294,7 +294,7 @@ location ~* ^/projects/(?:[\w-]*?/)?bgorges/classify-robot-auto-detected-images/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?bgorges/more-robot-images/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?bgorges/more-robot-images/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -302,7 +302,7 @@ location ~* ^/projects/(?:[\w-]*?/)?bgorges/more-robot-images/?(?:(classify|abou
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?bobbenjamin/hii-region-distance-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?bobbenjamin/hii-region-distance-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -310,7 +310,7 @@ location ~* ^/projects/(?:[\w-]*?/)?bobbenjamin/hii-region-distance-project/?(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?bradleyallf/bird-snacks/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?bradleyallf/bird-snacks/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -318,7 +318,7 @@ location ~* ^/projects/(?:[\w-]*?/)?bradleyallf/bird-snacks/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?brandonz/mer-spirit-pancam/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?brandonz/mer-spirit-pancam/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -326,7 +326,7 @@ location ~* ^/projects/(?:[\w-]*?/)?brandonz/mer-spirit-pancam/?(?:(classify|abo
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?brendanwebster/spiral-agn-hunt/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?brendanwebster/spiral-agn-hunt/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -334,7 +334,7 @@ location ~* ^/projects/(?:[\w-]*?/)?brendanwebster/spiral-agn-hunt/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?brit-org/fort-worth-prairie-phenology-at-brit/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?brit-org/fort-worth-prairie-phenology-at-brit/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -342,7 +342,7 @@ location ~* ^/projects/(?:[\w-]*?/)?brit-org/fort-worth-prairie-phenology-at-bri
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?bru01/validacion-de-mapas-de-bosques/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?bru01/validacion-de-mapas-de-bosques/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -350,7 +350,7 @@ location ~* ^/projects/(?:[\w-]*?/)?bru01/validacion-de-mapas-de-bosques/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?bw4sz/everglades-watch/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?bw4sz/everglades-watch/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -358,7 +358,7 @@ location ~* ^/projects/(?:[\w-]*?/)?bw4sz/everglades-watch/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?c0da/boundarylayer/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?c0da/boundarylayer/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -366,7 +366,7 @@ location ~* ^/projects/(?:[\w-]*?/)?c0da/boundarylayer/?(?:(classify|about)(?:/.
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?c0da/untitled-project-10-26-2018-2-56-55-pm/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?c0da/untitled-project-10-26-2018-2-56-55-pm/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -374,7 +374,7 @@ location ~* ^/projects/(?:[\w-]*?/)?c0da/untitled-project-10-26-2018-2-56-55-pm/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?callumbrogan/iwm-digital-collections/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?callumbrogan/iwm-digital-collections/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -382,7 +382,7 @@ location ~* ^/projects/(?:[\w-]*?/)?callumbrogan/iwm-digital-collections/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?caryelisbayonafigueroa/visual-inspection-of-high-normal-flux-ratio-dragns-7-8-2022-10-31-11-am/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?caryelisbayonafigueroa/visual-inspection-of-high-normal-flux-ratio-dragns-7-8-2022-10-31-11-am/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -390,7 +390,7 @@ location ~* ^/projects/(?:[\w-]*?/)?caryelisbayonafigueroa/visual-inspection-of-
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?cbellhouse/hi-jellyfish-classification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?cbellhouse/hi-jellyfish-classification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -398,7 +398,7 @@ location ~* ^/projects/(?:[\w-]*?/)?cbellhouse/hi-jellyfish-classification/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?cfllopes/splus-cacadores-de-astros/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?cfllopes/splus-cacadores-de-astros/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -406,7 +406,7 @@ location ~* ^/projects/(?:[\w-]*?/)?cfllopes/splus-cacadores-de-astros/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?charrod/genome-detectives-2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?charrod/genome-detectives-2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -414,7 +414,7 @@ location ~* ^/projects/(?:[\w-]*?/)?charrod/genome-detectives-2/?(?:(classify|ab
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?chris1010010/test-1961-census-liberated/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?chris1010010/test-1961-census-liberated/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -422,7 +422,7 @@ location ~* ^/projects/(?:[\w-]*?/)?chris1010010/test-1961-census-liberated/?(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?chrispattison/icg-drone-imagery-hack-day/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?chrispattison/icg-drone-imagery-hack-day/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -430,7 +430,7 @@ location ~* ^/projects/(?:[\w-]*?/)?chrispattison/icg-drone-imagery-hack-day/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?christy-dot-tremonti/manga-metallicity-maps/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?christy-dot-tremonti/manga-metallicity-maps/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -438,7 +438,7 @@ location ~* ^/projects/(?:[\w-]*?/)?christy-dot-tremonti/manga-metallicity-maps/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?clolson/palmer-amaranth-project-3-25-2020-8-30-16-am/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?clolson/palmer-amaranth-project-3-25-2020-8-30-16-am/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -446,7 +446,7 @@ location ~* ^/projects/(?:[\w-]*?/)?clolson/palmer-amaranth-project-3-25-2020-8-
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?cloud-class/clouds-with-a-type/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?cloud-class/clouds-with-a-type/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -454,7 +454,7 @@ location ~* ^/projects/(?:[\w-]*?/)?cloud-class/clouds-with-a-type/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?cole-dot-johnston/sphere/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?cole-dot-johnston/sphere/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -462,7 +462,7 @@ location ~* ^/projects/(?:[\w-]*?/)?cole-dot-johnston/sphere/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?cpook/street-scanner/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?cpook/street-scanner/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -470,7 +470,7 @@ location ~* ^/projects/(?:[\w-]*?/)?cpook/street-scanner/?(?:(classify|about)(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?cseidenstuecker/jeder-name-zahlt-dot-dot-dot/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?cseidenstuecker/jeder-name-zahlt-dot-dot-dot/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -478,7 +478,7 @@ location ~* ^/projects/(?:[\w-]*?/)?cseidenstuecker/jeder-name-zahlt-dot-dot-dot
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?cvergara/desy3-xcs/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?cvergara/desy3-xcs/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -486,7 +486,7 @@ location ~* ^/projects/(?:[\w-]*?/)?cvergara/desy3-xcs/?(?:(classify|about)(?:/.
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?cvergara/desy3-xcs-off-center-images-remade-msl17/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?cvergara/desy3-xcs-off-center-images-remade-msl17/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -494,7 +494,7 @@ location ~* ^/projects/(?:[\w-]*?/)?cvergara/desy3-xcs-off-center-images-remade-
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?danomc/rog-and-dan-do-all-the-clicks/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?danomc/rog-and-dan-do-all-the-clicks/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -502,7 +502,7 @@ location ~* ^/projects/(?:[\w-]*?/)?danomc/rog-and-dan-do-all-the-clicks/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?danomc/thales-v2-dot-2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?danomc/thales-v2-dot-2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -510,7 +510,7 @@ location ~* ^/projects/(?:[\w-]*?/)?danomc/thales-v2-dot-2/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?daviana/terrestrial-mammals-of-costa-rica/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?daviana/terrestrial-mammals-of-costa-rica/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -518,7 +518,7 @@ location ~* ^/projects/(?:[\w-]*?/)?daviana/terrestrial-mammals-of-costa-rica/?(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?deadinspiringproject/dead-inspiring/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?deadinspiringproject/dead-inspiring/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -526,7 +526,7 @@ location ~* ^/projects/(?:[\w-]*?/)?deadinspiringproject/dead-inspiring/?(?:(cla
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?duncanwp/finding-man-made-clouds/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?duncanwp/finding-man-made-clouds/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -534,7 +534,7 @@ location ~* ^/projects/(?:[\w-]*?/)?duncanwp/finding-man-made-clouds/?(?:(classi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?dvstark/manga-hi-visual-flagging/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?dvstark/manga-hi-visual-flagging/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -542,7 +542,7 @@ location ~* ^/projects/(?:[\w-]*?/)?dvstark/manga-hi-visual-flagging/?(?:(classi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ebellm/ztf-dippers/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ebellm/ztf-dippers/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -550,7 +550,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ebellm/ztf-dippers/?(?:(classify|about)(?:/.
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ebiharatns/tns-vs-2022/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ebiharatns/tns-vs-2022/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -558,7 +558,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ebiharatns/tns-vs-2022/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?eduardowoj/classificacao-fotos-fachada/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?eduardowoj/classificacao-fotos-fachada/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -566,7 +566,7 @@ location ~* ^/projects/(?:[\w-]*?/)?eduardowoj/classificacao-fotos-fachada/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?eelsirhc/crater-mapping/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?eelsirhc/crater-mapping/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -574,7 +574,7 @@ location ~* ^/projects/(?:[\w-]*?/)?eelsirhc/crater-mapping/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?emmyd/lunar-landmarks/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?emmyd/lunar-landmarks/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -582,7 +582,7 @@ location ~* ^/projects/(?:[\w-]*?/)?emmyd/lunar-landmarks/?(?:(classify|about)(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ericahopkins/lenses/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ericahopkins/lenses/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -590,7 +590,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ericahopkins/lenses/?(?:(classify|about)(?:/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?escordato/santa-clara-river-valley-camera-trapping/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?escordato/santa-clara-river-valley-camera-trapping/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -598,7 +598,7 @@ location ~* ^/projects/(?:[\w-]*?/)?escordato/santa-clara-river-valley-camera-tr
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?esterfiorillo/teste-dengue/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?esterfiorillo/teste-dengue/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -606,7 +606,7 @@ location ~* ^/projects/(?:[\w-]*?/)?esterfiorillo/teste-dengue/?(?:(classify|abo
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ezzjcw/mars-in-development/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ezzjcw/mars-in-development/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -614,7 +614,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ezzjcw/mars-in-development/?(?:(classify|abo
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ezzjcw/mars-in-motion-v2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ezzjcw/mars-in-motion-v2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -622,7 +622,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ezzjcw/mars-in-motion-v2/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?fbarwell/investigating-the-triggering-of-3cr-radio-galaxies/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?fbarwell/investigating-the-triggering-of-3cr-radio-galaxies/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -630,7 +630,7 @@ location ~* ^/projects/(?:[\w-]*?/)?fbarwell/investigating-the-triggering-of-3cr
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?fiona-penguin/penguin-watch-3-dot-0/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?fiona-penguin/penguin-watch-3-dot-0/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -638,7 +638,7 @@ location ~* ^/projects/(?:[\w-]*?/)?fiona-penguin/penguin-watch-3-dot-0/?(?:(cla
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?fltest/phs/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?fltest/phs/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -646,7 +646,7 @@ location ~* ^/projects/(?:[\w-]*?/)?fltest/phs/?(?:(classify|about)(?:/.+?)?)?/?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?flzaah/dental-equipment-recognition-using-artificial-intelligence/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?flzaah/dental-equipment-recognition-using-artificial-intelligence/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -654,7 +654,7 @@ location ~* ^/projects/(?:[\w-]*?/)?flzaah/dental-equipment-recognition-using-ar
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?fmaviane/arabidopsis-symptoms/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?fmaviane/arabidopsis-symptoms/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -662,7 +662,7 @@ location ~* ^/projects/(?:[\w-]*?/)?fmaviane/arabidopsis-symptoms/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?fmaviane/downy-mildew-annotation/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?fmaviane/downy-mildew-annotation/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -670,7 +670,7 @@ location ~* ^/projects/(?:[\w-]*?/)?fmaviane/downy-mildew-annotation/?(?:(classi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?fullfact/the-full-fact-pilot/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?fullfact/the-full-fact-pilot/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -678,7 +678,7 @@ location ~* ^/projects/(?:[\w-]*?/)?fullfact/the-full-fact-pilot/?(?:(classify|a
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?fulsdavid/catalina-outer-solar-system-survey-verification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?fulsdavid/catalina-outer-solar-system-survey-verification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -686,7 +686,7 @@ location ~* ^/projects/(?:[\w-]*?/)?fulsdavid/catalina-outer-solar-system-survey
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?gabriel-azevedo/jellyfish-hsc/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?gabriel-azevedo/jellyfish-hsc/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -694,7 +694,7 @@ location ~* ^/projects/(?:[\w-]*?/)?gabriel-azevedo/jellyfish-hsc/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?gary-complexzoo/anomaly-in-the-emu-zoo-03-11-2021-20-30-42/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?gary-complexzoo/anomaly-in-the-emu-zoo-03-11-2021-20-30-42/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -702,7 +702,7 @@ location ~* ^/projects/(?:[\w-]*?/)?gary-complexzoo/anomaly-in-the-emu-zoo-03-11
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?gbgraham19/embedded-clusters-round-2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?gbgraham19/embedded-clusters-round-2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -710,7 +710,7 @@ location ~* ^/projects/(?:[\w-]*?/)?gbgraham19/embedded-clusters-round-2/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?gbrammer/charge-high-z-targets/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?gbrammer/charge-high-z-targets/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -718,7 +718,7 @@ location ~* ^/projects/(?:[\w-]*?/)?gbrammer/charge-high-z-targets/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?gcwrp/grand-canyon-ecoregion/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?gcwrp/grand-canyon-ecoregion/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -726,7 +726,7 @@ location ~* ^/projects/(?:[\w-]*?/)?gcwrp/grand-canyon-ecoregion/?(?:(classify|a
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?gekewoudstra/distribution-of-prey-and-predator/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?gekewoudstra/distribution-of-prey-and-predator/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -734,7 +734,7 @@ location ~* ^/projects/(?:[\w-]*?/)?gekewoudstra/distribution-of-prey-and-predat
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?getty/gri-artist-letters/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?getty/gri-artist-letters/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -742,7 +742,7 @@ location ~* ^/projects/(?:[\w-]*?/)?getty/gri-artist-letters/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?getty/gri-shunk-image-tagging/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?getty/gri-shunk-image-tagging/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -750,7 +750,7 @@ location ~* ^/projects/(?:[\w-]*?/)?getty/gri-shunk-image-tagging/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?guangwenchen/ai-for-radio-astronomy/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?guangwenchen/ai-for-radio-astronomy/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -758,7 +758,7 @@ location ~* ^/projects/(?:[\w-]*?/)?guangwenchen/ai-for-radio-astronomy/?(?:(cla
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?h-spiers/etch-a-cell-mito-mega-mix/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?h-spiers/etch-a-cell-mito-mega-mix/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -766,7 +766,7 @@ location ~* ^/projects/(?:[\w-]*?/)?h-spiers/etch-a-cell-mito-mega-mix/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?h-spiers/etch-a-cell-nuclei-explorer/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?h-spiers/etch-a-cell-nuclei-explorer/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -774,7 +774,7 @@ location ~* ^/projects/(?:[\w-]*?/)?h-spiers/etch-a-cell-nuclei-explorer/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?h-spiers/science-scribbler-all-or-nothing/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?h-spiers/science-scribbler-all-or-nothing/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -782,7 +782,7 @@ location ~* ^/projects/(?:[\w-]*?/)?h-spiers/science-scribbler-all-or-nothing/?(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hellenmonteirop/a-quest-for-jellyfish-galaxies-in-s-plus-data/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hellenmonteirop/a-quest-for-jellyfish-galaxies-in-s-plus-data/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -790,7 +790,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hellenmonteirop/a-quest-for-jellyfish-galaxi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?henry-dot-leopold/apollo/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?henry-dot-leopold/apollo/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -798,7 +798,7 @@ location ~* ^/projects/(?:[\w-]*?/)?henry-dot-leopold/apollo/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?henrycooke/classifying-c60-si-111-spm-images/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?henrycooke/classifying-c60-si-111-spm-images/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -806,7 +806,7 @@ location ~* ^/projects/(?:[\w-]*?/)?henrycooke/classifying-c60-si-111-spm-images
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?highzgal/claudia/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?highzgal/claudia/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -814,7 +814,7 @@ location ~* ^/projects/(?:[\w-]*?/)?highzgal/claudia/?(?:(classify|about)(?:/.+?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hiro-ono/ai4mars-gold-standard-labeling/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hiro-ono/ai4mars-gold-standard-labeling/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -822,7 +822,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hiro-ono/ai4mars-gold-standard-labeling/?(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hiro-ono/the-planet-arroyo/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hiro-ono/the-planet-arroyo/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -830,7 +830,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hiro-ono/the-planet-arroyo/?(?:(classify|abo
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hollyel/nmnh-epicc-specimen-assessment/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hollyel/nmnh-epicc-specimen-assessment/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -838,7 +838,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hollyel/nmnh-epicc-specimen-assessment/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/superwasp-bhh-gold-standard/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/superwasp-bhh-gold-standard/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -846,7 +846,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/superwasp-bhh-gold-standard/?(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/wisp-passive-galaxy-search/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/wisp-passive-galaxy-search/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -854,7 +854,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/wisp-passive-galaxy-search/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/zaks-magical-my-eyes-catalogue/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/zaks-magical-my-eyes-catalogue/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -862,7 +862,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hughdickinson/zaks-magical-my-eyes-catalogue
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hunterlc/elves-images/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hunterlc/elves-images/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -870,7 +870,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hunterlc/elves-images/?(?:(classify|about)(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hunterlc/larger-satellite-identification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hunterlc/larger-satellite-identification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -878,7 +878,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hunterlc/larger-satellite-identification/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hunterlc/satellite-galaxies-identification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hunterlc/satellite-galaxies-identification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -886,7 +886,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hunterlc/satellite-galaxies-identification/?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?hunterlc/satellite-inspection-deep-dive/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?hunterlc/satellite-inspection-deep-dive/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -894,7 +894,7 @@ location ~* ^/projects/(?:[\w-]*?/)?hunterlc/satellite-inspection-deep-dive/?(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?imjs/roof-shape/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?imjs/roof-shape/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -902,7 +902,7 @@ location ~* ^/projects/(?:[\w-]*?/)?imjs/roof-shape/?(?:(classify|about)(?:/.+?)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?inigoval/mightee-test-set/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?inigoval/mightee-test-set/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -910,7 +910,7 @@ location ~* ^/projects/(?:[\w-]*?/)?inigoval/mightee-test-set/?(?:(classify|abou
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ioannis666/detecting-marine-litter-v-1/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ioannis666/detecting-marine-litter-v-1/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -918,7 +918,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ioannis666/detecting-marine-litter-v-1/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ioannis6666/detecting-marine-litter-v-2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ioannis6666/detecting-marine-litter-v-2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -926,7 +926,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ioannis6666/detecting-marine-litter-v-2/?(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?itrharrison/superclassify/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?itrharrison/superclassify/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -934,7 +934,7 @@ location ~* ^/projects/(?:[\w-]*?/)?itrharrison/superclassify/?(?:(classify|abou
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?j-dot-popp/hsc-clump-ml-checker/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?j-dot-popp/hsc-clump-ml-checker/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -942,7 +942,7 @@ location ~* ^/projects/(?:[\w-]*?/)?j-dot-popp/hsc-clump-ml-checker/?(?:(classif
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?j-dot-sadek/historia-plantarum/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?j-dot-sadek/historia-plantarum/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -950,7 +950,7 @@ location ~* ^/projects/(?:[\w-]*?/)?j-dot-sadek/historia-plantarum/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?j-dot-sadek/historia-plantarum-2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?j-dot-sadek/historia-plantarum-2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -958,7 +958,7 @@ location ~* ^/projects/(?:[\w-]*?/)?j-dot-sadek/historia-plantarum-2/?(?:(classi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jaygattuso/cartes-de-visite-faces/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jaygattuso/cartes-de-visite-faces/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -966,7 +966,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jaygattuso/cartes-de-visite-faces/?(?:(class
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jen-dot-schultze/northern-illinois-wildlife/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jen-dot-schultze/northern-illinois-wildlife/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -974,7 +974,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jen-dot-schultze/northern-illinois-wildlife/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jenwalls/aces-compact-source-removal/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jenwalls/aces-compact-source-removal/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -982,7 +982,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jenwalls/aces-compact-source-removal/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jeyhansk/ceers-visual-classifications/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jeyhansk/ceers-visual-classifications/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -990,7 +990,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jeyhansk/ceers-visual-classifications/?(?:(c
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jimmafeni/road-cam-annotation/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jimmafeni/road-cam-annotation/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -998,7 +998,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jimmafeni/road-cam-annotation/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jmaple/napc-summer-2022/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jmaple/napc-summer-2022/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1006,7 +1006,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jmaple/napc-summer-2022/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jmschell/tar-pits-zooniverse-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jmschell/tar-pits-zooniverse-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1014,7 +1014,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jmschell/tar-pits-zooniverse-project/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jnaiman/nlp-test/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jnaiman/nlp-test/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1022,7 +1022,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jnaiman/nlp-test/?(?:(classify|about)(?:/.+?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jnaiman/prototype-document-layout-analysis/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jnaiman/prototype-document-layout-analysis/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1030,7 +1030,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jnaiman/prototype-document-layout-analysis/?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?joaofranca/lastberu/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?joaofranca/lastberu/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1038,7 +1038,7 @@ location ~* ^/projects/(?:[\w-]*?/)?joaofranca/lastberu/?(?:(classify|about)(?:/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jonesr8/phoenix-zoo-trailblazers-wildlife-watch/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jonesr8/phoenix-zoo-trailblazers-wildlife-watch/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1046,7 +1046,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jonesr8/phoenix-zoo-trailblazers-wildlife-wa
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jonnypierce/do-agn-triggering-mechanisms-vary-with-radio-power/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jonnypierce/do-agn-triggering-mechanisms-vary-with-radio-power/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1054,7 +1054,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jonnypierce/do-agn-triggering-mechanisms-var
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?joseph-meli/the-malta-dockyard-collection/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?joseph-meli/the-malta-dockyard-collection/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1062,7 +1062,7 @@ location ~* ^/projects/(?:[\w-]*?/)?joseph-meli/the-malta-dockyard-collection/?(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?justacea/genome-instability/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?justacea/genome-instability/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1070,7 +1070,7 @@ location ~* ^/projects/(?:[\w-]*?/)?justacea/genome-instability/?(?:(classify|ab
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?jypark/something-odd-about-that-plant/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?jypark/something-odd-about-that-plant/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1078,7 +1078,7 @@ location ~* ^/projects/(?:[\w-]*?/)?jypark/something-odd-about-that-plant/?(?:(c
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?karts/eye-on-the-apostles/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?karts/eye-on-the-apostles/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1086,7 +1086,7 @@ location ~* ^/projects/(?:[\w-]*?/)?karts/eye-on-the-apostles/?(?:(classify|abou
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?kcotar/galah-spectra/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?kcotar/galah-spectra/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1094,7 +1094,7 @@ location ~* ^/projects/(?:[\w-]*?/)?kcotar/galah-spectra/?(?:(classify|about)(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?kerrypaterson/saguaro-ml/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?kerrypaterson/saguaro-ml/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1102,7 +1102,7 @@ location ~* ^/projects/(?:[\w-]*?/)?kerrypaterson/saguaro-ml/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?klmasters/spiral-mask-inspection/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?klmasters/spiral-mask-inspection/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1110,7 +1110,7 @@ location ~* ^/projects/(?:[\w-]*?/)?klmasters/spiral-mask-inspection/?(?:(classi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?kpillai/masonry-crack-pattern-similarity-assessment-all-images/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?kpillai/masonry-crack-pattern-similarity-assessment-all-images/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1118,7 +1118,7 @@ location ~* ^/projects/(?:[\w-]*?/)?kpillai/masonry-crack-pattern-similarity-ass
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?kpillai/masonry-crack-pattern-similarity-assessment-fe-images/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?kpillai/masonry-crack-pattern-similarity-assessment-fe-images/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1126,7 +1126,7 @@ location ~* ^/projects/(?:[\w-]*?/)?kpillai/masonry-crack-pattern-similarity-ass
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?krojas26/experts-visual-inspection-experiment/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?krojas26/experts-visual-inspection-experiment/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1134,7 +1134,7 @@ location ~* ^/projects/(?:[\w-]*?/)?krojas26/experts-visual-inspection-experimen
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?kunzel/getting-ready-for-mars/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?kunzel/getting-ready-for-mars/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1142,7 +1142,7 @@ location ~* ^/projects/(?:[\w-]*?/)?kunzel/getting-ready-for-mars/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?larondalab/egg-hunt-ovarian-follicle-identification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?larondalab/egg-hunt-ovarian-follicle-identification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1150,7 +1150,7 @@ location ~* ^/projects/(?:[\w-]*?/)?larondalab/egg-hunt-ovarian-follicle-identif
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?lauraneckstein/scribes-of-the-cairo-geniza/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?lauraneckstein/scribes-of-the-cairo-geniza/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1158,7 +1158,7 @@ location ~* ^/projects/(?:[\w-]*?/)?lauraneckstein/scribes-of-the-cairo-geniza/?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?leeskelvin/green-valley-census/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?leeskelvin/green-valley-census/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1166,7 +1166,7 @@ location ~* ^/projects/(?:[\w-]*?/)?leeskelvin/green-valley-census/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?lennea/testing-itcz-image-classification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?lennea/testing-itcz-image-classification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1174,7 +1174,7 @@ location ~* ^/projects/(?:[\w-]*?/)?lennea/testing-itcz-image-classification/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?lesb20/x-ray-lab-lets-go/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?lesb20/x-ray-lab-lets-go/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1182,7 +1182,7 @@ location ~* ^/projects/(?:[\w-]*?/)?lesb20/x-ray-lab-lets-go/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ltom/artillery-crater-analysis-and-detection-engine-arcade/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ltom/artillery-crater-analysis-and-detection-engine-arcade/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1190,7 +1190,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ltom/artillery-crater-analysis-and-detection
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?lucasgautheron/pretty-diagrams-and-the-evolution-of-costly-cultural-norms/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?lucasgautheron/pretty-diagrams-and-the-evolution-of-costly-cultural-norms/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1198,7 +1198,7 @@ location ~* ^/projects/(?:[\w-]*?/)?lucasgautheron/pretty-diagrams-and-the-evolu
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?maayane/ztf-transients-hosts-identification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?maayane/ztf-transients-hosts-identification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1206,7 +1206,7 @@ location ~* ^/projects/(?:[\w-]*?/)?maayane/ztf-transients-hosts-identification/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?manasi99/classifying-data-from-the-new-pipeline/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?manasi99/classifying-data-from-the-new-pipeline/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1214,7 +1214,7 @@ location ~* ^/projects/(?:[\w-]*?/)?manasi99/classifying-data-from-the-new-pipel
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?manasisharma/gattini-ir-ml-classifier/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?manasisharma/gattini-ir-ml-classifier/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1222,7 +1222,7 @@ location ~* ^/projects/(?:[\w-]*?/)?manasisharma/gattini-ir-ml-classifier/?(?:(c
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?manateetristanity/whats-in-a-whistle/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?manateetristanity/whats-in-a-whistle/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1230,7 +1230,7 @@ location ~* ^/projects/(?:[\w-]*?/)?manateetristanity/whats-in-a-whistle/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mangroveturtle/mangrove-spy-usvi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mangroveturtle/mangrove-spy-usvi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1238,7 +1238,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mangroveturtle/mangrove-spy-usvi/?(?:(classi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?manolopoulaki/xcs-dr2-sdss-cluster-zoo/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?manolopoulaki/xcs-dr2-sdss-cluster-zoo/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1246,7 +1246,7 @@ location ~* ^/projects/(?:[\w-]*?/)?manolopoulaki/xcs-dr2-sdss-cluster-zoo/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?marchett/icy-world-surface-analogues/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?marchett/icy-world-surface-analogues/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1254,7 +1254,7 @@ location ~* ^/projects/(?:[\w-]*?/)?marchett/icy-world-surface-analogues/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?marckuchner/galex-zoo/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?marckuchner/galex-zoo/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1262,7 +1262,7 @@ location ~* ^/projects/(?:[\w-]*?/)?marckuchner/galex-zoo/?(?:(classify|about)(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mariateresanardone/relabelling-jwst-galaxy-images/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mariateresanardone/relabelling-jwst-galaxy-images/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1270,7 +1270,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mariateresanardone/relabelling-jwst-galaxy-i
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?matheusbarrosp/dataset-mp-pavimentacao/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?matheusbarrosp/dataset-mp-pavimentacao/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1278,7 +1278,7 @@ location ~* ^/projects/(?:[\w-]*?/)?matheusbarrosp/dataset-mp-pavimentacao/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mathphys/mergers-among-sdss-agn-hosts/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mathphys/mergers-among-sdss-agn-hosts/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1286,7 +1286,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mathphys/mergers-among-sdss-agn-hosts/?(?:(c
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?matthewtpenny/testmishaps/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?matthewtpenny/testmishaps/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1294,7 +1294,7 @@ location ~* ^/projects/(?:[\w-]*?/)?matthewtpenny/testmishaps/?(?:(classify|abou
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?max-dot-larreur/2022-field-season/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?max-dot-larreur/2022-field-season/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1302,7 +1302,7 @@ location ~* ^/projects/(?:[\w-]*?/)?max-dot-larreur/2022-field-season/?(?:(class
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mbatsaris/detecting-marine-litter-v-3/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mbatsaris/detecting-marine-litter-v-3/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1310,7 +1310,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mbatsaris/detecting-marine-litter-v-3/?(?:(c
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mbatsaris1/detecting-marine-litter-v-10/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mbatsaris1/detecting-marine-litter-v-10/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1318,7 +1318,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mbatsaris1/detecting-marine-litter-v-10/?(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mbatsaris1/detecting-marine-litter-v-8/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mbatsaris1/detecting-marine-litter-v-8/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1326,7 +1326,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mbatsaris1/detecting-marine-litter-v-8/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mbatsaris1/detecting-marine-litter-v-9/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mbatsaris1/detecting-marine-litter-v-9/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1334,7 +1334,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mbatsaris1/detecting-marine-litter-v-9/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mbbagley/ceers-science-sprint/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mbbagley/ceers-science-sprint/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1342,7 +1342,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mbbagley/ceers-science-sprint/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mbbagley/egs-classifications/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mbbagley/egs-classifications/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1350,7 +1350,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mbbagley/egs-classifications/?(?:(classify|a
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mbbagley/werls-classifications/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mbbagley/werls-classifications/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1358,7 +1358,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mbbagley/werls-classifications/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?md68135/nfn-private-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?md68135/nfn-private-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1366,7 +1366,7 @@ location ~* ^/projects/(?:[\w-]*?/)?md68135/nfn-private-project/?(?:(classify|ab
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mdipompeo/wise-hsc-agn/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mdipompeo/wise-hsc-agn/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1374,7 +1374,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mdipompeo/wise-hsc-agn/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?meghanparry/wilson-historic-district/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?meghanparry/wilson-historic-district/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1382,7 +1382,7 @@ location ~* ^/projects/(?:[\w-]*?/)?meghanparry/wilson-historic-district/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?midniteclub/sud-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?midniteclub/sud-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1390,7 +1390,7 @@ location ~* ^/projects/(?:[\w-]*?/)?midniteclub/sud-project/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?miglioa/m4/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?miglioa/m4/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1398,7 +1398,7 @@ location ~* ^/projects/(?:[\w-]*?/)?miglioa/m4/?(?:(classify|about)(?:/.+?)?)?/?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mike-dot-jones-dot-astro/blue-blobs/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mike-dot-jones-dot-astro/blue-blobs/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1406,7 +1406,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mike-dot-jones-dot-astro/blue-blobs/?(?:(cla
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mike-dot-jones-dot-astro/ufds-in-smudges/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mike-dot-jones-dot-astro/ufds-in-smudges/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1414,7 +1414,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mike-dot-jones-dot-astro/ufds-in-smudges/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mikewalmsley/galaxy-judges/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mikewalmsley/galaxy-judges/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1422,7 +1422,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mikewalmsley/galaxy-judges/?(?:(classify|abo
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mjh22/lofar-galaxy-zoo/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mjh22/lofar-galaxy-zoo/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1430,7 +1430,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mjh22/lofar-galaxy-zoo/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mjh22/mightee-galaxy-zoo/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mjh22/mightee-galaxy-zoo/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1438,7 +1438,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mjh22/mightee-galaxy-zoo/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mnmarjadi/internal-test/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mnmarjadi/internal-test/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1446,7 +1446,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mnmarjadi/internal-test/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mouse13/deeplense-sample/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mouse13/deeplense-sample/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1454,7 +1454,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mouse13/deeplense-sample/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mph51/cambridge-university-herbarium-elm-leaf-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mph51/cambridge-university-herbarium-elm-leaf-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1462,7 +1462,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mph51/cambridge-university-herbarium-elm-lea
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?mschwamb/planet-four-boulders/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?mschwamb/planet-four-boulders/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1470,7 +1470,7 @@ location ~* ^/projects/(?:[\w-]*?/)?mschwamb/planet-four-boulders/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?msemczuk/warps-zoo-tng/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?msemczuk/warps-zoo-tng/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1478,7 +1478,7 @@ location ~* ^/projects/(?:[\w-]*?/)?msemczuk/warps-zoo-tng/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?nationallibraryofnewzealand/cartes-de-re-visites/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?nationallibraryofnewzealand/cartes-de-re-visites/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1486,7 +1486,7 @@ location ~* ^/projects/(?:[\w-]*?/)?nationallibraryofnewzealand/cartes-de-re-vis
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ncoco/foto-fachada-nati/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ncoco/foto-fachada-nati/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1494,7 +1494,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ncoco/foto-fachada-nati/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ncoco/foto-fachada-rha/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ncoco/foto-fachada-rha/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1502,7 +1502,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ncoco/foto-fachada-rha/?(?:(classify|about)(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ndeg/wallaby-decals-trial/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ndeg/wallaby-decals-trial/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1510,7 +1510,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ndeg/wallaby-decals-trial/?(?:(classify|abou
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?nelvy/beard-clasification-test/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?nelvy/beard-clasification-test/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1518,7 +1518,7 @@ location ~* ^/projects/(?:[\w-]*?/)?nelvy/beard-clasification-test/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?nelvy/beard-satellites-clasification-test2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?nelvy/beard-satellites-clasification-test2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1526,7 +1526,7 @@ location ~* ^/projects/(?:[\w-]*?/)?nelvy/beard-satellites-clasification-test2/?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?newberry/art-in-miniature/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?newberry/art-in-miniature/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1534,7 +1534,7 @@ location ~* ^/projects/(?:[\w-]*?/)?newberry/art-in-miniature/?(?:(classify|abou
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?newberry/postcard-tag-old/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?newberry/postcard-tag-old/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1542,7 +1542,7 @@ location ~* ^/projects/(?:[\w-]*?/)?newberry/postcard-tag-old/?(?:(classify|abou
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?nicholasfoster/te-manahuna-aoraki/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?nicholasfoster/te-manahuna-aoraki/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1550,7 +1550,7 @@ location ~* ^/projects/(?:[\w-]*?/)?nicholasfoster/te-manahuna-aoraki/?(?:(class
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?nicoadams/environment-project-clump-vetting/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?nicoadams/environment-project-clump-vetting/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1558,7 +1558,7 @@ location ~* ^/projects/(?:[\w-]*?/)?nicoadams/environment-project-clump-vetting/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?nora-dot-eisner/classifying-the-classified/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?nora-dot-eisner/classifying-the-classified/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1566,7 +1566,7 @@ location ~* ^/projects/(?:[\w-]*?/)?nora-dot-eisner/classifying-the-classified/?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?oboucher/identification-of-contrails/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?oboucher/identification-of-contrails/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1574,7 +1574,7 @@ location ~* ^/projects/(?:[\w-]*?/)?oboucher/identification-of-contrails/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?panthera-research/private-camera-catalogue/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?panthera-research/private-camera-catalogue/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1582,7 +1582,7 @@ location ~* ^/projects/(?:[\w-]*?/)?panthera-research/private-camera-catalogue/?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?peak-finder/diffraction-peak-labelling/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?peak-finder/diffraction-peak-labelling/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1590,7 +1590,7 @@ location ~* ^/projects/(?:[\w-]*?/)?peak-finder/diffraction-peak-labelling/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?penguintom79/kittiwake-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?penguintom79/kittiwake-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1598,7 +1598,7 @@ location ~* ^/projects/(?:[\w-]*?/)?penguintom79/kittiwake-project/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?petitpadawan/soleil-detection/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?petitpadawan/soleil-detection/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1606,7 +1606,7 @@ location ~* ^/projects/(?:[\w-]*?/)?petitpadawan/soleil-detection/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?peto582/linear-object-classification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?peto582/linear-object-classification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1614,7 +1614,7 @@ location ~* ^/projects/(?:[\w-]*?/)?peto582/linear-object-classification/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?psweeney/marginal-botany/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?psweeney/marginal-botany/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1622,7 +1622,7 @@ location ~* ^/projects/(?:[\w-]*?/)?psweeney/marginal-botany/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ptsws/fossil/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ptsws/fossil/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1630,7 +1630,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ptsws/fossil/?(?:(classify|about)(?:/.+?)?)?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ptsws/fossil2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ptsws/fossil2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1638,7 +1638,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ptsws/fossil2/?(?:(classify|about)(?:/.+?)?)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?ptsws/hsc-ssp-deep/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?ptsws/hsc-ssp-deep/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1646,7 +1646,7 @@ location ~* ^/projects/(?:[\w-]*?/)?ptsws/hsc-ssp-deep/?(?:(classify|about)(?:/.
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?rachaelorben/oregon-seabirds/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?rachaelorben/oregon-seabirds/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1654,7 +1654,7 @@ location ~* ^/projects/(?:[\w-]*?/)?rachaelorben/oregon-seabirds/?(?:(classify|a
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?radurevutchi/sound-descriptors-actions/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?radurevutchi/sound-descriptors-actions/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1662,7 +1662,7 @@ location ~* ^/projects/(?:[\w-]*?/)?radurevutchi/sound-descriptors-actions/?(?:(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?rahulsrajeshh/neuroai-2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?rahulsrajeshh/neuroai-2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1670,7 +1670,7 @@ location ~* ^/projects/(?:[\w-]*?/)?rahulsrajeshh/neuroai-2/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?rahulsrajeshh/orchvate-da-aptitude-test-new/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?rahulsrajeshh/orchvate-da-aptitude-test-new/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1678,7 +1678,7 @@ location ~* ^/projects/(?:[\w-]*?/)?rahulsrajeshh/orchvate-da-aptitude-test-new/
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?rahulsrajeshh/orchvate-da-aptitude-test-september-2024/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?rahulsrajeshh/orchvate-da-aptitude-test-september-2024/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1686,7 +1686,7 @@ location ~* ^/projects/(?:[\w-]*?/)?rahulsrajeshh/orchvate-da-aptitude-test-sept
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?rdonner/subaru-galaxies/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?rdonner/subaru-galaxies/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1694,7 +1694,7 @@ location ~* ^/projects/(?:[\w-]*?/)?rdonner/subaru-galaxies/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?restor/tag-trees-deprecated/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?restor/tag-trees-deprecated/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1702,7 +1702,7 @@ location ~* ^/projects/(?:[\w-]*?/)?restor/tag-trees-deprecated/?(?:(classify|ab
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?rns461/deeds-3-13-2025-4-39-35-pm/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?rns461/deeds-3-13-2025-4-39-35-pm/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1710,7 +1710,7 @@ location ~* ^/projects/(?:[\w-]*?/)?rns461/deeds-3-13-2025-4-39-35-pm/?(?:(class
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?rswcit/ztf-public-msip-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?rswcit/ztf-public-msip-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1718,7 +1718,7 @@ location ~* ^/projects/(?:[\w-]*?/)?rswcit/ztf-public-msip-project/?(?:(classify
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?safmcadmin/fishstory-validation-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?safmcadmin/fishstory-validation-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1726,7 +1726,7 @@ location ~* ^/projects/(?:[\w-]*?/)?safmcadmin/fishstory-validation-project/?(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sandorkruk/bars-jwst/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sandorkruk/bars-jwst/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1734,7 +1734,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sandorkruk/bars-jwst/?(?:(classify|about)(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sassydumbledore/chimp-and-see-miniproject-draconian-kerfuffle/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sassydumbledore/chimp-and-see-miniproject-draconian-kerfuffle/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1742,7 +1742,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sassydumbledore/chimp-and-see-miniproject-dr
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sassydumbledore/chimp-matching-mini-project-ethereal-lotus/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sassydumbledore/chimp-matching-mini-project-ethereal-lotus/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1750,7 +1750,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sassydumbledore/chimp-matching-mini-project-
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sdp27/the-osteoarthritis-x-ray-classification-research-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sdp27/the-osteoarthritis-x-ray-classification-research-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1758,7 +1758,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sdp27/the-osteoarthritis-x-ray-classificatio
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?serc/chesapeake-bay-parasite-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?serc/chesapeake-bay-parasite-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1766,7 +1766,7 @@ location ~* ^/projects/(?:[\w-]*?/)?serc/chesapeake-bay-parasite-project/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?serc/invader-id-target-taxa/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?serc/invader-id-target-taxa/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1774,7 +1774,7 @@ location ~* ^/projects/(?:[\w-]*?/)?serc/invader-id-target-taxa/?(?:(classify|ab
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?serc/oyster-cam/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?serc/oyster-cam/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1782,7 +1782,7 @@ location ~* ^/projects/(?:[\w-]*?/)?serc/oyster-cam/?(?:(classify|about)(?:/.+?)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?serjeant/galaxy-smudges/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?serjeant/galaxy-smudges/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1790,7 +1790,7 @@ location ~* ^/projects/(?:[\w-]*?/)?serjeant/galaxy-smudges/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b3-catalogv3-vi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b3-catalogv3-vi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1798,7 +1798,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b3-catalogv3-vi/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b4-catalogv3-vi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b4-catalogv3-vi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1806,7 +1806,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b4-catalogv3-vi/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b5-catalogv3-vi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b5-catalogv3-vi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1814,7 +1814,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b5-catalogv3-vi/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b6-catalogv3-vi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b6-catalogv3-vi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1822,7 +1822,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b6-catalogv3-vi/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b6b-catalogv3-vi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b6b-catalogv3-vi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1830,7 +1830,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b6b-catalogv3-vi/?(?:(cla
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b6c-catalogv3-vi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b6c-catalogv3-vi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1838,7 +1838,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sherman-dot-sydney/b6c-catalogv3-vi/?(?:(cla
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?siljeg/apertif-catalogue/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?siljeg/apertif-catalogue/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1846,7 +1846,7 @@ location ~* ^/projects/(?:[\w-]*?/)?siljeg/apertif-catalogue/?(?:(classify|about
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sladeaa/soundscape-monitoring/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sladeaa/soundscape-monitoring/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1854,7 +1854,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sladeaa/soundscape-monitoring/?(?:(classify|
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sophmjewell/desi-disk-dominated-agn-hosts/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sophmjewell/desi-disk-dominated-agn-hosts/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1862,7 +1862,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sophmjewell/desi-disk-dominated-agn-hosts/?(
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?squidgame/anita/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?squidgame/anita/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1870,7 +1870,7 @@ location ~* ^/projects/(?:[\w-]*?/)?squidgame/anita/?(?:(classify|about)(?:/.+?)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?squidgame/dr-poissant/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?squidgame/dr-poissant/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1878,7 +1878,7 @@ location ~* ^/projects/(?:[\w-]*?/)?squidgame/dr-poissant/?(?:(classify|about)(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?squidgame/ihncheol/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?squidgame/ihncheol/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1886,7 +1886,7 @@ location ~* ^/projects/(?:[\w-]*?/)?squidgame/ihncheol/?(?:(classify|about)(?:/.
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?squidgame/mason/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?squidgame/mason/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1894,7 +1894,7 @@ location ~* ^/projects/(?:[\w-]*?/)?squidgame/mason/?(?:(classify|about)(?:/.+?)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?squidgame/micky/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?squidgame/micky/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1902,7 +1902,7 @@ location ~* ^/projects/(?:[\w-]*?/)?squidgame/micky/?(?:(classify|about)(?:/.+?)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?squidgame/rachel/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?squidgame/rachel/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1910,7 +1910,7 @@ location ~* ^/projects/(?:[\w-]*?/)?squidgame/rachel/?(?:(classify|about)(?:/.+?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?squidgame/stefan/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?squidgame/stefan/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1918,7 +1918,7 @@ location ~* ^/projects/(?:[\w-]*?/)?squidgame/stefan/?(?:(classify|about)(?:/.+?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?stephenresearch/arctic-aerial-surveys/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?stephenresearch/arctic-aerial-surveys/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1926,7 +1926,7 @@ location ~* ^/projects/(?:[\w-]*?/)?stephenresearch/arctic-aerial-surveys/?(?:(c
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?stephenresearch/red-panda-behaviour/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?stephenresearch/red-panda-behaviour/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1934,7 +1934,7 @@ location ~* ^/projects/(?:[\w-]*?/)?stephenresearch/red-panda-behaviour/?(?:(cla
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?stothart/sable-island-horse-condition-project/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?stothart/sable-island-horse-condition-project/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1942,7 +1942,7 @@ location ~* ^/projects/(?:[\w-]*?/)?stothart/sable-island-horse-condition-projec
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?suja82/dustdevilsctx/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?suja82/dustdevilsctx/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1950,7 +1950,7 @@ location ~* ^/projects/(?:[\w-]*?/)?suja82/dustdevilsctx/?(?:(classify|about)(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?surhudm/barred-galaxy-classification-hsc/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?surhudm/barred-galaxy-classification-hsc/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1958,7 +1958,7 @@ location ~* ^/projects/(?:[\w-]*?/)?surhudm/barred-galaxy-classification-hsc/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?swapnaneel/finding-ring-dwarf-galaxy/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?swapnaneel/finding-ring-dwarf-galaxy/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1966,7 +1966,7 @@ location ~* ^/projects/(?:[\w-]*?/)?swapnaneel/finding-ring-dwarf-galaxy/?(?:(cl
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sweetime/jellyfish-galaxies/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sweetime/jellyfish-galaxies/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1974,7 +1974,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sweetime/jellyfish-galaxies/?(?:(classify|ab
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sydney-b-sherman/shela-b3-eazy-py-massive-vi-number-2/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sydney-b-sherman/shela-b3-eazy-py-massive-vi-number-2/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1982,7 +1982,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sydney-b-sherman/shela-b3-eazy-py-massive-vi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sydney-b-sherman/shela-scirange-m-1e11-visual-inspection/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sydney-b-sherman/shela-scirange-m-1e11-visual-inspection/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1990,7 +1990,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sydney-b-sherman/shela-scirange-m-1e11-visua
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sydney-sherman19/shela-b5-eazy-py-massive-vi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sydney-sherman19/shela-b5-eazy-py-massive-vi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -1998,7 +1998,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sydney-sherman19/shela-b5-eazy-py-massive-vi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sydney-sherman19/shela-b6-eazy-py-massive-vi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sydney-sherman19/shela-b6-eazy-py-massive-vi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2006,7 +2006,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sydney-sherman19/shela-b6-eazy-py-massive-vi
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sydneyunilibrary/detective-fiction/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sydneyunilibrary/detective-fiction/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2014,7 +2014,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sydneyunilibrary/detective-fiction/?(?:(clas
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?sydsherman19/shela-b4-eazy-py-massive-vi/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?sydsherman19/shela-b4-eazy-py-massive-vi/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2022,7 +2022,7 @@ location ~* ^/projects/(?:[\w-]*?/)?sydsherman19/shela-b4-eazy-py-massive-vi/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?tharinduj/g-band-variables-test/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?tharinduj/g-band-variables-test/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2030,7 +2030,7 @@ location ~* ^/projects/(?:[\w-]*?/)?tharinduj/g-band-variables-test/?(?:(classif
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?tstewart656/morphology-of-spogs/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?tstewart656/morphology-of-spogs/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2038,7 +2038,7 @@ location ~* ^/projects/(?:[\w-]*?/)?tstewart656/morphology-of-spogs/?(?:(classif
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?vardanp91/frick/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?vardanp91/frick/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2046,7 +2046,7 @@ location ~* ^/projects/(?:[\w-]*?/)?vardanp91/frick/?(?:(classify|about)(?:/.+?)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?vmehta/splash-sxdf-eelg/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?vmehta/splash-sxdf-eelg/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2054,7 +2054,7 @@ location ~* ^/projects/(?:[\w-]*?/)?vmehta/splash-sxdf-eelg/?(?:(classify|about)
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?warworld2/ww2dead/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?warworld2/ww2dead/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2062,7 +2062,7 @@ location ~* ^/projects/(?:[\w-]*?/)?warworld2/ww2dead/?(?:(classify|about)(?:/.+
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?wcagizmo/early-christian-papyri/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?wcagizmo/early-christian-papyri/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2070,7 +2070,7 @@ location ~* ^/projects/(?:[\w-]*?/)?wcagizmo/early-christian-papyri/?(?:(classif
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?weijmans/hi-weave-apertif-classification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?weijmans/hi-weave-apertif-classification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2078,7 +2078,7 @@ location ~* ^/projects/(?:[\w-]*?/)?weijmans/hi-weave-apertif-classification/?(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?weiyinko/find-the-watermelons-6-22-2017-6-09-17-pm/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?weiyinko/find-the-watermelons-6-22-2017-6-09-17-pm/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2086,7 +2086,7 @@ location ~* ^/projects/(?:[\w-]*?/)?weiyinko/find-the-watermelons-6-22-2017-6-09
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?westerlund2/wd2-variable-star-zoo/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?westerlund2/wd2-variable-star-zoo/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2094,7 +2094,7 @@ location ~* ^/projects/(?:[\w-]*?/)?westerlund2/wd2-variable-star-zoo/?(?:(class
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?wkiri/mars-landmarks/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?wkiri/mars-landmarks/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2102,7 +2102,7 @@ location ~* ^/projects/(?:[\w-]*?/)?wkiri/mars-landmarks/?(?:(classify|about)(?:
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?wragge/sydney-stock-exchange/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?wragge/sydney-stock-exchange/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2110,7 +2110,7 @@ location ~* ^/projects/(?:[\w-]*?/)?wragge/sydney-stock-exchange/?(?:(classify|a
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?yjangordon/vlass-variables/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?yjangordon/vlass-variables/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2118,7 +2118,7 @@ location ~* ^/projects/(?:[\w-]*?/)?yjangordon/vlass-variables/?(?:(classify|abo
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?yntzevanderhoek/nkuba/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?yntzevanderhoek/nkuba/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;
@@ -2126,7 +2126,7 @@ location ~* ^/projects/(?:[\w-]*?/)?yntzevanderhoek/nkuba/?(?:(classify|about)(?
     include /etc/nginx/az-proxy-headers.conf;
 }
 
-location ~* ^/projects/(?:[\w-]*?/)?zoeyyy/glitch-classification/?(?:(classify|about)(?:/.+?)?)?/?$ {
+location ~* ^/projects/(?:[\w-]*?/)?zoeyyy/glitch-classification/?(?:(classify|about|stats)(?:/.+?)?)?/?$ {
     rewrite (?i)\.(jp(e)?g|gif|png|svg|ico|txt|mp(3|4)|webm|og(a|g|m|v|x)|spx|opus|pdf|ttf|tar|gz|tgz|bz2|tbz2|zip)$ https://static.zooniverse.org/$proxy_path$request_uri;
 
     resolver 1.1.1.1;


### PR DESCRIPTION
Removes `stats`  from the regex that determines which project-level pages get redirected to PFE. These project stats pages will soon be served by FEM (fe-projects). Staging (frontend.preview) already does this by not having any PFE redirects. 

Do not deploy this until the required FEM changes have been deployed, or else all project stats pages will become FEM 404s.